### PR TITLE
v2.0 M3: 下载能力（任务过滤器 / t.me 链接 / 相册聚合 / 元数据 sidecar）

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -221,7 +221,7 @@ func executeMode(
 // logHistoryMediaCount 在下载前统计并打印聊天媒体总数（近似值）；
 // 统计失败仅告警不阻断，返回非 nil 仅表示 ctx 已取消
 func logHistoryMediaCount(ctx context.Context, client *telegram.Client, log *logger.Logger, chatID int64) error {
-	total, err := client.CountHistoryMedia(ctx, chatID)
+	total, err := client.CountHistoryMedia(ctx, chatID, nil)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
 			return err

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -9,6 +9,7 @@ download:
   max_concurrent: 5    # 同时下载的文件数
   batch_size: 100      # 每批拉取的历史消息数
   partition_size: 100  # 历史下载在途媒体上限（扫描最多领先下载的数量）
+  save_metadata: false # 为 true 时在每个下载文件旁写 <文件>.json 元数据（caption/发送者/日期等）
   disable_classify_by_type: false  # 按媒体类型归档默认开启；设为 true 可恢复旧版扁平目录布局
 
 chat:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/joho/godotenv"
 	"gopkg.in/yaml.v3"
@@ -68,6 +69,8 @@ type DownloadConfig struct {
 	MaxConcurrent int    `yaml:"max_concurrent"` // 同时下载的文件数
 	BatchSize     int    `yaml:"batch_size"`     // 每批拉取的历史消息数
 	PartitionSize int    `yaml:"partition_size"` // 历史下载在途媒体上限（扫描最多领先下载的数量）
+	// SaveMetadata 为 true 时在每个下载文件旁写 <文件>.json 元数据（caption/发送者/日期等）
+	SaveMetadata bool `yaml:"save_metadata"`
 	// DisableClassifyByType 为 true 时关闭按媒体类型归档（默认归档开启）
 	DisableClassifyByType bool `yaml:"disable_classify_by_type"`
 }
@@ -263,6 +266,10 @@ func loadDownloadConfig(config *Config) {
 		if partition, err := strconv.Atoi(partitionSize); err == nil {
 			config.Download.PartitionSize = partition
 		}
+	}
+
+	if saveMetadata := os.Getenv("SAVE_METADATA"); saveMetadata != "" {
+		config.Download.SaveMetadata = saveMetadata == "1" || strings.EqualFold(saveMetadata, "true")
 	}
 }
 

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -4,6 +4,7 @@ package downloader
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
@@ -49,6 +50,9 @@ type MediaInfo struct {
 	ChatID    int64
 	Date      time.Time
 	TaskID    string // 所属任务ID（CLI 模式使用合成ID）
+	AlbumID   int64  // Telegram 相册（media_album_id），0 = 不属于相册
+	Caption   string // 消息 caption 文本（供元数据 sidecar）
+	SenderID  int64  // 发送者 user/chat id（供元数据 sidecar）
 }
 
 // RecordStatus 下载记录状态
@@ -83,6 +87,7 @@ type Downloader struct {
 	downloadFunc   func(context.Context, *MediaInfo, string) error
 	pauseFunc      func(context.Context, *MediaInfo) error
 	classifyByType atomic.Bool // Web 端可运行时切换，下载 goroutine 并发读取
+	saveMetadata   atomic.Bool // 下载完成后是否写元数据 sidecar
 	recordFunc     func(context.Context, RecordEvent)
 	// duplicateLookupFunc 按 unique_id 查找已完成下载的既有文件路径（内容级去重），可为 nil
 	duplicateLookupFunc func(context.Context, string) (string, bool)
@@ -249,6 +254,11 @@ func (d *Downloader) SetRecordFunc(fn func(context.Context, RecordEvent)) {
 // 已完成下载的既有文件路径（ok=false 表示无记录）。由持有 store 的一方注入。
 func (d *Downloader) SetDuplicateLookupFunc(fn func(ctx context.Context, uniqueID string) (existingPath string, ok bool)) {
 	d.duplicateLookupFunc = fn
+}
+
+// SetSaveMetadata 设置是否在下载完成后写 <文件>.json 元数据 sidecar
+func (d *Downloader) SetSaveMetadata(v bool) {
+	d.saveMetadata.Store(v)
 }
 
 // SetMaxConcurrent updates the number of media files that may download at once.
@@ -824,7 +834,35 @@ func (d *Downloader) DownloadMedia(ctx context.Context, media *MediaInfo) error 
 	d.updateStats(true, actual)
 	d.finishProgress(progressKey, media, "completed")
 	d.record(ctx, RecordEvent{Media: media, Status: RecordCompleted, FilePath: filePath, DownloadedSize: actual})
+	d.writeMetadataSidecar(media, filePath)
 	return nil
+}
+
+// writeMetadataSidecar 在开关开启时写 <文件>.json 元数据（best-effort，失败仅告警）
+func (d *Downloader) writeMetadataSidecar(media *MediaInfo, filePath string) {
+	if !d.saveMetadata.Load() {
+		return
+	}
+	payload := map[string]any{
+		"message_id": media.MessageID,
+		"chat_id":    media.ChatID,
+		"date":       media.Date.Unix(),
+		"sender_id":  media.SenderID,
+		"caption":    media.Caption,
+		"album_id":   media.AlbumID,
+		"media_type": media.MediaType,
+		"file_name":  media.FileName,
+		"file_size":  media.FileSize,
+		"mime_type":  media.MimeType,
+	}
+	data, err := json.MarshalIndent(payload, "", "  ")
+	if err != nil {
+		d.logger.Warn("序列化元数据失败: %v", err)
+		return
+	}
+	if err := os.WriteFile(filePath+".json", data, 0o644); err != nil { // #nosec G306 -- 元数据非敏感
+		d.logger.Warn("写入元数据 sidecar 失败: %v", err)
+	}
 }
 
 // copyFile 将 src 复制为 dst：先写入同目录临时文件再原子 rename，
@@ -871,6 +909,10 @@ func (d *Downloader) planMediaPath(media *MediaInfo) (chatDir, fileName, filePat
 	chatDir = filepath.Join(d.downloadPath, fmt.Sprintf("chat_%d", media.ChatID))
 	if d.classifyByType.Load() {
 		chatDir = filepath.Join(chatDir, classifyDir(media.MediaType))
+	}
+	if media.AlbumID != 0 {
+		// 同一相册的文件归入同一子目录
+		chatDir = filepath.Join(chatDir, fmt.Sprintf("album_%d", media.AlbumID))
 	}
 
 	fileName = media.FileName

--- a/internal/downloader/spec.go
+++ b/internal/downloader/spec.go
@@ -7,7 +7,76 @@ type HistorySpec struct {
 	TaskID string
 	// FromMessageID 是续扫游标（最后已扫描页的最旧 message_id），0 表示从最新消息开始
 	FromMessageID int64
+	// MessageID 非 0 时为单消息下载任务（t.me 消息链接）：只下载该消息的媒体，不扫描历史
+	MessageID int64
+	// Filters 是任务级媒体过滤条件（零值 = 不过滤）
+	Filters HistoryFilters
 	// RetryMessageIDs 是恢复任务时需优先补下的消息（进程重启清扫的中断行，
 	// 比游标更新，仅靠游标续扫会永久漏掉）
 	RetryMessageIDs []int64
+}
+
+// HistoryFilters 是任务级媒体过滤条件；JSON 序列化后持久化在 tasks.filters 列，
+// 并作为 POST /api/tasks 的 filters 字段
+type HistoryFilters struct {
+	// MediaTypes 是要下载的媒体类型子集（photo/video/document/animation/audio/voice），空 = 全部
+	MediaTypes []string `json:"media_types,omitempty"`
+	// DateFrom/DateTo 是消息日期区间（unix 秒，闭区间），0 = 不限
+	DateFrom int64 `json:"date_from,omitempty"`
+	DateTo   int64 `json:"date_to,omitempty"`
+	// MaxFileSize 是单文件大小上限（字节），0 = 不限
+	MaxFileSize int64 `json:"max_file_size,omitempty"`
+}
+
+// IsZero 报告过滤器是否为零值（不过滤）
+func (f HistoryFilters) IsZero() bool {
+	return len(f.MediaTypes) == 0 && f.DateFrom == 0 && f.DateTo == 0 && f.MaxFileSize == 0
+}
+
+// Match 报告一个媒体项（类型/消息日期 unix 秒/文件字节数）是否通过过滤
+func (f HistoryFilters) Match(mediaType string, date, size int64) bool {
+	if len(f.MediaTypes) > 0 {
+		ok := false
+		for _, t := range f.MediaTypes {
+			if t == mediaType {
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			return false
+		}
+	}
+	if f.DateFrom != 0 && date < f.DateFrom {
+		return false
+	}
+	if f.DateTo != 0 && date > f.DateTo {
+		return false
+	}
+	if f.MaxFileSize > 0 && size > f.MaxFileSize {
+		return false
+	}
+	return true
+}
+
+// ValidMediaTypes 是 MediaTypes 的合法取值集合
+var ValidMediaTypes = map[string]bool{
+	"photo": true, "video": true, "document": true,
+	"animation": true, "audio": true, "voice": true,
+}
+
+// Validate 校验过滤器字段合法性，返回首个问题的描述（合法时为空串）
+func (f HistoryFilters) Validate() string {
+	for _, t := range f.MediaTypes {
+		if !ValidMediaTypes[t] {
+			return "无效的媒体类型: " + t
+		}
+	}
+	if f.DateFrom != 0 && f.DateTo != 0 && f.DateFrom > f.DateTo {
+		return "date_from 不能晚于 date_to"
+	}
+	if f.MaxFileSize < 0 {
+		return "max_file_size 不能为负"
+	}
+	return ""
 }

--- a/internal/queue/manager.go
+++ b/internal/queue/manager.go
@@ -323,12 +323,23 @@ func (m *Manager) runHistoryTask(ctx context.Context, t *task) {
 	m.persist(t)
 	m.notify(t)
 
-	// 计数阶段：下载开始前先统计媒体总数并落库+推送，前端立即可见"共约 N 个"
+	t.mu.Lock()
+	isSingleMessage := t.messageID != 0
+	mediaTypes := t.filters.MediaTypes
+	t.mu.Unlock()
+
+	// 计数阶段：下载开始前先统计媒体总数并落库+推送，前端立即可见"共约 N 个"；
+	// 单消息任务无需统计，总数恒为 1
 	t.mu.Lock()
 	t.phase = phaseCounting
 	t.mu.Unlock()
 	m.notify(t)
-	if total, cntErr := m.client.CountHistoryMedia(taskCtx, t.chatID); cntErr != nil {
+	if isSingleMessage {
+		t.mu.Lock()
+		t.expectedTotal = 1
+		t.mu.Unlock()
+		m.persist(t)
+	} else if total, cntErr := m.client.CountHistoryMedia(taskCtx, t.chatID, mediaTypes); cntErr != nil {
 		if taskCtx.Err() == nil {
 			m.logger.Warn("统计任务 %s 媒体总数失败，回退为未知总数: %v", t.id, cntErr)
 		}
@@ -345,6 +356,8 @@ func (m *Manager) runHistoryTask(ctx context.Context, t *task) {
 		ChatID:        t.chatID,
 		TaskID:        t.id,
 		FromMessageID: t.scanCursor,
+		MessageID:     t.messageID,
+		Filters:       t.filters,
 	}
 	resumed := t.resumed
 	t.mu.Unlock()
@@ -429,36 +442,42 @@ func (m *Manager) scheduleRetry(t *task, attempt int, cause error) {
 }
 
 // Enqueue 创建并提交一个新任务。history 任务进入有界 worker 池排队；
-// monitor 任务立即以独立 goroutine 长期运行（不占用 history 配额），chatID 为 0 表示停止监控。
-func (m *Manager) Enqueue(kind Kind, chatID int64, chatTitle string) (TaskDTO, error) {
+// monitor 任务立即以独立 goroutine 长期运行（不占用 history 配额），ChatID 为 0 表示停止监控。
+// spec 携带 ChatID 以及 history 任务的过滤器/单消息参数（monitor 忽略后两者）。
+func (m *Manager) Enqueue(kind Kind, spec downloader.HistorySpec, chatTitle string) (TaskDTO, error) {
 	switch kind {
 	case KindHistory:
-		return m.enqueueHistory(chatID, chatTitle)
+		return m.enqueueHistory(spec, chatTitle)
 	case KindMonitor:
-		return m.enqueueMonitor(chatID, chatTitle)
+		return m.enqueueMonitor(spec.ChatID, chatTitle)
 	default:
 		return TaskDTO{}, fmt.Errorf("未知任务类型: %s", kind)
 	}
 }
 
 // enqueueHistory 创建 history 任务、持久化后投递给 worker 池；
-// 同一 chatID 已存在排队中/运行中的 history 任务时拒绝创建，避免重复下载
-func (m *Manager) enqueueHistory(chatID int64, chatTitle string) (TaskDTO, error) {
+// 排队中/运行中的重复任务拒绝创建（整聊天任务按 chatID 去重，单消息任务按 (chatID, messageID) 去重）
+func (m *Manager) enqueueHistory(spec downloader.HistorySpec, chatTitle string) (TaskDTO, error) {
 	m.mu.Lock()
 	for _, existing := range m.tasks {
-		if existing.kind != KindHistory || existing.chatID != chatID {
+		if existing.kind != KindHistory || existing.chatID != spec.ChatID {
 			continue
 		}
 		existing.mu.Lock()
 		status := existing.status
+		existingMsgID := existing.messageID
 		existing.mu.Unlock()
-		if status == StatusQueued || status == StatusRunning {
-			m.mu.Unlock()
-			return TaskDTO{}, fmt.Errorf("该会话已有下载任务在队列中")
+		if status != StatusQueued && status != StatusRunning {
+			continue
 		}
+		if existingMsgID != spec.MessageID {
+			continue // 单消息任务与整聊天任务互不冲突，不同消息的单消息任务亦然
+		}
+		m.mu.Unlock()
+		return TaskDTO{}, fmt.Errorf("该会话已有下载任务在队列中")
 	}
 
-	t := newTask(KindHistory, chatID, chatTitle)
+	t := newTask(KindHistory, spec, chatTitle)
 	if err := m.createTaskRow(t); err != nil {
 		m.mu.Unlock()
 		return TaskDTO{}, err
@@ -495,7 +514,7 @@ func (m *Manager) enqueueMonitor(chatID int64, chatTitle string) (TaskDTO, error
 		return TaskDTO{}, nil
 	}
 
-	t := newTask(KindMonitor, chatID, chatTitle)
+	t := newTask(KindMonitor, downloader.HistorySpec{ChatID: chatID}, chatTitle)
 	t.mu.Lock()
 	t.status = StatusRunning
 	now := time.Now()
@@ -646,13 +665,14 @@ func (m *Manager) Retry(id string) (TaskDTO, error) {
 	}
 
 	t.mu.Lock()
-	status, kind, chatID, chatTitle := t.status, t.kind, t.chatID, t.chatTitle
+	status, kind, chatTitle := t.status, t.kind, t.chatTitle
+	spec := downloader.HistorySpec{ChatID: t.chatID, Filters: t.filters, MessageID: t.messageID}
 	t.mu.Unlock()
 
 	if status != StatusFailed && status != StatusCanceled {
 		return TaskDTO{}, fmt.Errorf("任务状态为 %s，不允许重试", status)
 	}
-	return m.Enqueue(kind, chatID, chatTitle)
+	return m.Enqueue(kind, spec, chatTitle)
 }
 
 // createTaskRow 按任务当前快照在 store 中创建持久化记录
@@ -669,6 +689,8 @@ func (m *Manager) createTaskRow(t *task) error {
 		ExpectedTotal: dto.ExpectedTotal,
 		ScanCursor:    dto.ScanCursor,
 		Attempts:      dto.Attempts,
+		Filters:       t.filtersJSON(),
+		MessageID:     dto.MessageID,
 	}
 	if err := m.store.CreateTask(context.Background(), row); err != nil {
 		return fmt.Errorf("创建任务记录失败: %w", err)

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -41,7 +41,7 @@ const (
 // ChatDownloader 是 Manager 依赖的最小接口（而非直接依赖 *telegram.Client），
 // 使本包可在无真实 TDLib 连接的情况下进行单元测试。
 type ChatDownloader interface {
-	CountHistoryMedia(ctx context.Context, chatID int64) (int64, error)
+	CountHistoryMedia(ctx context.Context, chatID int64, mediaTypes []string) (int64, error)
 	DownloadHistoryMedia(ctx context.Context, spec downloader.HistorySpec) error
 	SetMonitorTask(taskID string, chatID int64)
 	SetRecordFunc(fn func(context.Context, downloader.RecordEvent))
@@ -72,4 +72,8 @@ type TaskDTO struct {
 	ScanCursor int64 `json:"scan_cursor,omitempty"`
 	// Attempts 是自动重试已消耗的次数
 	Attempts int `json:"attempts,omitempty"`
+	// Filters 是任务级过滤条件（nil = 不过滤）
+	Filters *downloader.HistoryFilters `json:"filters,omitempty"`
+	// MessageID 非 0 时为单消息下载任务（t.me 消息链接）
+	MessageID int64 `json:"message_id,omitempty"`
 }

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -87,7 +87,7 @@ func (f *fakeClient) setCountErr(chatID int64, err error) {
 	f.mu.Unlock()
 }
 
-func (f *fakeClient) CountHistoryMedia(_ context.Context, chatID int64) (int64, error) {
+func (f *fakeClient) CountHistoryMedia(_ context.Context, chatID int64, _ []string) (int64, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	if err := f.countErrs[chatID]; err != nil {
@@ -185,7 +185,7 @@ func TestEnqueueLifecycle_QueuedRunningCompleted(t *testing.T) {
 	fc := newFakeClient()
 	m := NewManager(fc, newTestStore(t), logger.New(logger.LevelError), 1, 0)
 
-	dto, err := m.Enqueue(KindHistory, 1, "chat-1")
+	dto, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 1}, "chat-1")
 	if err != nil {
 		t.Fatalf("Enqueue() error = %v", err)
 	}
@@ -214,7 +214,7 @@ func TestRunHistoryTask_CountsBeforeDownload(t *testing.T) {
 	t.Cleanup(cancel)
 	go m.Run(ctx)
 
-	dto, err := m.Enqueue(KindHistory, 1, "chat-1")
+	dto, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 1}, "chat-1")
 	if err != nil {
 		t.Fatalf("Enqueue() error = %v", err)
 	}
@@ -252,7 +252,7 @@ func TestRunHistoryTask_CountFailureFallsBack(t *testing.T) {
 	m, fc := newTestManager(t, 1)
 	fc.setCountErr(1, errors.New("count boom"))
 
-	dto, err := m.Enqueue(KindHistory, 1, "chat-1")
+	dto, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 1}, "chat-1")
 	if err != nil {
 		t.Fatalf("Enqueue() error = %v", err)
 	}
@@ -268,13 +268,13 @@ func TestRunHistoryTask_CountFailureFallsBack(t *testing.T) {
 func TestCancel_QueuedTask(t *testing.T) {
 	m, fc := newTestManager(t, 1)
 
-	dto1, err := m.Enqueue(KindHistory, 1, "chat-1")
+	dto1, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 1}, "chat-1")
 	if err != nil {
 		t.Fatalf("Enqueue(task1) error = %v", err)
 	}
 	waitForStatus(t, m, dto1.ID, StatusRunning, testWaitTimeout)
 
-	dto2, err := m.Enqueue(KindHistory, 2, "chat-2")
+	dto2, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 2}, "chat-2")
 	if err != nil {
 		t.Fatalf("Enqueue(task2) error = %v", err)
 	}
@@ -302,13 +302,13 @@ func TestCancel_QueuedTask(t *testing.T) {
 func TestCancel_QueuedTask_DoneClosedOnce(t *testing.T) {
 	m, fc := newTestManager(t, 1)
 
-	dto1, err := m.Enqueue(KindHistory, 1, "chat-1")
+	dto1, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 1}, "chat-1")
 	if err != nil {
 		t.Fatalf("Enqueue(task1) error = %v", err)
 	}
 	waitForStatus(t, m, dto1.ID, StatusRunning, testWaitTimeout)
 
-	dto2, err := m.Enqueue(KindHistory, 2, "chat-2")
+	dto2, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 2}, "chat-2")
 	if err != nil {
 		t.Fatalf("Enqueue(task2) error = %v", err)
 	}
@@ -343,7 +343,7 @@ func TestCancel_QueuedTask_DoneClosedOnce(t *testing.T) {
 func TestCancel_RunningTask(t *testing.T) {
 	m, fc := newTestManager(t, 1)
 
-	dto, err := m.Enqueue(KindHistory, 1, "chat-1")
+	dto, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 1}, "chat-1")
 	if err != nil {
 		t.Fatalf("Enqueue() error = %v", err)
 	}
@@ -360,7 +360,7 @@ func TestCancel_RunningTask(t *testing.T) {
 func TestRetry_FailedTask(t *testing.T) {
 	m, fc := newTestManager(t, 1)
 
-	dto, err := m.Enqueue(KindHistory, 1, "chat-1")
+	dto, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 1}, "chat-1")
 	if err != nil {
 		t.Fatalf("Enqueue() error = %v", err)
 	}
@@ -390,7 +390,7 @@ func TestRetry_FailedTask(t *testing.T) {
 	}
 
 	t.Run("disallowed on non-terminal status", func(t *testing.T) {
-		dto2, err := m.Enqueue(KindHistory, 2, "chat-2")
+		dto2, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 2}, "chat-2")
 		if err != nil {
 			t.Fatalf("Enqueue() error = %v", err)
 		}
@@ -407,13 +407,13 @@ func TestRetry_FailedTask(t *testing.T) {
 func TestMaxConcurrentTasks_Serializes(t *testing.T) {
 	m, fc := newTestManager(t, 1)
 
-	dto1, err := m.Enqueue(KindHistory, 1, "chat-1")
+	dto1, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 1}, "chat-1")
 	if err != nil {
 		t.Fatalf("Enqueue(task1) error = %v", err)
 	}
 	waitForStatus(t, m, dto1.ID, StatusRunning, testWaitTimeout)
 
-	dto2, err := m.Enqueue(KindHistory, 2, "chat-2")
+	dto2, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 2}, "chat-2")
 	if err != nil {
 		t.Fatalf("Enqueue(task2) error = %v", err)
 	}
@@ -436,7 +436,7 @@ func TestMaxConcurrentTasks_Serializes(t *testing.T) {
 func TestMonitor_DoesNotBlockHistoryQueue(t *testing.T) {
 	m, fc := newTestManager(t, 1)
 
-	dto1, err := m.Enqueue(KindHistory, 1, "chat-1")
+	dto1, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 1}, "chat-1")
 	if err != nil {
 		t.Fatalf("Enqueue(history) error = %v", err)
 	}
@@ -446,7 +446,7 @@ func TestMonitor_DoesNotBlockHistoryQueue(t *testing.T) {
 	var monDTO TaskDTO
 	var monErr error
 	go func() {
-		monDTO, monErr = m.Enqueue(KindMonitor, 999, "monitor-chat")
+		monDTO, monErr = m.Enqueue(KindMonitor, downloader.HistorySpec{ChatID: 999}, "monitor-chat")
 		close(done)
 	}()
 
@@ -465,7 +465,7 @@ func TestMonitor_DoesNotBlockHistoryQueue(t *testing.T) {
 		t.Fatalf("client monitor association = (%s,%d), want (%s,999)", mid, mchat, monDTO.ID)
 	}
 
-	stopped, err := m.Enqueue(KindMonitor, 0, "")
+	stopped, err := m.Enqueue(KindMonitor, downloader.HistorySpec{ChatID: 0}, "")
 	if err != nil {
 		t.Fatalf("Enqueue(stop monitor) error = %v", err)
 	}
@@ -485,13 +485,13 @@ func TestMonitor_DoesNotBlockHistoryQueue(t *testing.T) {
 func TestMonitor_SwitchCancelsPrevious(t *testing.T) {
 	m, fc := newTestManager(t, 1)
 
-	first, err := m.Enqueue(KindMonitor, 111, "first")
+	first, err := m.Enqueue(KindMonitor, downloader.HistorySpec{ChatID: 111}, "first")
 	if err != nil {
 		t.Fatalf("Enqueue(first monitor) error = %v", err)
 	}
 	waitForStatus(t, m, first.ID, StatusRunning, testWaitTimeout)
 
-	second, err := m.Enqueue(KindMonitor, 222, "second")
+	second, err := m.Enqueue(KindMonitor, downloader.HistorySpec{ChatID: 222}, "second")
 	if err != nil {
 		t.Fatalf("Enqueue(second monitor) error = %v", err)
 	}
@@ -508,17 +508,17 @@ func TestMonitor_SwitchCancelsPrevious(t *testing.T) {
 func TestEnqueueHistory_DuplicateChatRejected(t *testing.T) {
 	m, fc := newTestManager(t, 1)
 
-	dto1, err := m.Enqueue(KindHistory, 1, "chat-1")
+	dto1, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 1}, "chat-1")
 	if err != nil {
 		t.Fatalf("Enqueue(task1) error = %v", err)
 	}
 	waitForStatus(t, m, dto1.ID, StatusRunning, testWaitTimeout)
 
-	if _, err := m.Enqueue(KindHistory, 1, "chat-1"); err == nil {
+	if _, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 1}, "chat-1"); err == nil {
 		t.Fatal("对处于 running 状态的同一 chat_id 重复 Enqueue 应返回错误")
 	}
 
-	dto2, err := m.Enqueue(KindHistory, 2, "chat-2")
+	dto2, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 2}, "chat-2")
 	if err != nil {
 		t.Fatalf("Enqueue(task2) error = %v", err)
 	}
@@ -527,7 +527,7 @@ func TestEnqueueHistory_DuplicateChatRejected(t *testing.T) {
 		t.Fatalf("task2 should still be queued while task1 occupies the only worker, got %+v ok=%v", got, ok)
 	}
 
-	if _, err := m.Enqueue(KindHistory, 2, "chat-2"); err == nil {
+	if _, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 2}, "chat-2"); err == nil {
 		t.Fatal("对处于 queued 状态的同一 chat_id 重复 Enqueue 应返回错误")
 	}
 
@@ -547,7 +547,7 @@ func TestEnqueueHistory_DuplicateChatRejected(t *testing.T) {
 	waitForStatus(t, m, dto2.ID, StatusRunning, testWaitTimeout)
 
 	// task1 已终结，chat-1 应允许重新入队
-	dto3, err := m.Enqueue(KindHistory, 1, "chat-1")
+	dto3, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 1}, "chat-1")
 	if err != nil {
 		t.Fatalf("任务终结后重新 Enqueue(chat-1) error = %v", err)
 	}
@@ -643,7 +643,7 @@ func TestNewManager_ResumesInterruptedTasksFromStore(t *testing.T) {
 func TestHandleRecordEvent_AsyncPersistPreservesOrder(t *testing.T) {
 	m, fc := newTestManager(t, 1)
 
-	dto, err := m.Enqueue(KindHistory, 1, "chat-1")
+	dto, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 1}, "chat-1")
 	if err != nil {
 		t.Fatalf("Enqueue() error = %v", err)
 	}
@@ -698,7 +698,7 @@ func TestRunHistoryTask_AutoRetry(t *testing.T) {
 	t.Cleanup(cancel)
 	go m.Run(ctx)
 
-	dto, err := m.Enqueue(KindHistory, 1, "chat-1")
+	dto, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 1}, "chat-1")
 	if err != nil {
 		t.Fatalf("Enqueue() error = %v", err)
 	}
@@ -720,5 +720,58 @@ func TestRunHistoryTask_AutoRetry(t *testing.T) {
 	fc.mu.Unlock()
 	if calls != 3 {
 		t.Fatalf("DownloadHistoryMedia 调用次数 = %d, want 3（首跑+2次重试）", calls)
+	}
+}
+
+// TestEnqueue_FiltersFlowThroughSpecAndRetry 验证任务过滤器与单消息参数：
+// 传入 Enqueue 的过滤器随 HistorySpec 抵达 client、落库持久化，且手动 Retry 后仍然携带
+func TestEnqueue_FiltersFlowThroughSpecAndRetry(t *testing.T) {
+	fc := newFakeClient()
+	st := newTestStore(t)
+	m := NewManager(fc, st, logger.New(logger.LevelError), 1, 0)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go m.Run(ctx)
+
+	filters := downloader.HistoryFilters{MediaTypes: []string{"photo"}, DateFrom: 1700000000, MaxFileSize: 1 << 20}
+	dto, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 1, Filters: filters}, "chat-1")
+	if err != nil {
+		t.Fatalf("Enqueue() error = %v", err)
+	}
+	if dto.Filters == nil || dto.Filters.MediaTypes[0] != "photo" {
+		t.Fatalf("DTO 未携带过滤器: %+v", dto.Filters)
+	}
+
+	waitForStatus(t, m, dto.ID, StatusRunning, testWaitTimeout)
+	fc.setErr(dto.ID, errors.New("boom"))
+	fc.release(dto.ID)
+	waitForStatus(t, m, dto.ID, StatusFailed, testWaitTimeout)
+
+	fc.mu.Lock()
+	specs := fc.specs[dto.ID]
+	fc.mu.Unlock()
+	if len(specs) != 1 || specs[0].Filters.MaxFileSize != 1<<20 || len(specs[0].Filters.MediaTypes) != 1 {
+		t.Fatalf("spec 未携带过滤器: %+v", specs)
+	}
+
+	row, err := st.GetTask(context.Background(), dto.ID)
+	if err != nil || row == nil || row.Filters == "" {
+		t.Fatalf("过滤器未落库: row=%+v err=%v", row, err)
+	}
+
+	// 手动重试产生新任务，过滤器随行
+	retryDTO, err := m.Retry(dto.ID)
+	if err != nil {
+		t.Fatalf("Retry() error = %v", err)
+	}
+	waitForStatus(t, m, retryDTO.ID, StatusRunning, testWaitTimeout)
+	fc.release(retryDTO.ID)
+	waitForStatus(t, m, retryDTO.ID, StatusCompleted, testWaitTimeout)
+	fc.mu.Lock()
+	retrySpecs := fc.specs[retryDTO.ID]
+	fc.mu.Unlock()
+	if len(retrySpecs) != 1 || retrySpecs[0].Filters.DateFrom != 1700000000 {
+		t.Fatalf("Retry 未携带过滤器: %+v", retrySpecs)
 	}
 }

--- a/internal/queue/task.go
+++ b/internal/queue/task.go
@@ -2,6 +2,7 @@ package queue
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -40,12 +41,14 @@ type task struct {
 	phase         string // 运行阶段（counting/downloading），仅内存态
 	expectedTotal int64  // 下载前统计出的媒体总数（近似值），0 表示未知
 
-	scannedMessages int64     // 历史扫描已翻阅的消息数（仅内存态，运行中有值）
-	foundMedia      int64     // 历史扫描累计发现的媒体数（仅内存态，运行中有值）
-	scanCursor      int64     // 历史扫描游标（持久化，重启恢复续扫起点）
-	attempts        int       // 自动重试已消耗次数（持久化）
-	resumed         bool      // 本任务是否为进程重启后恢复（需补下中断行）
-	lastScanNotify  time.Time // 上次扫描进度对外推送时刻，用于限频
+	scannedMessages int64                     // 历史扫描已翻阅的消息数（仅内存态，运行中有值）
+	foundMedia      int64                     // 历史扫描累计发现的媒体数（仅内存态，运行中有值）
+	scanCursor      int64                     // 历史扫描游标（持久化，重启恢复续扫起点）
+	attempts        int                       // 自动重试已消耗次数（持久化）
+	resumed         bool                      // 本任务是否为进程重启后恢复（需补下中断行）
+	filters         downloader.HistoryFilters // 任务级过滤条件（持久化，零值 = 不过滤）
+	messageID       int64                     // 单消息任务的目标消息 id（持久化，0 = 整聊天）
+	lastScanNotify  time.Time                 // 上次扫描进度对外推送时刻，用于限频
 
 	lastRecordNotify      time.Time // 上次下载记录对外推送时刻，用于限频
 	recordTrailingPending bool      // 是否已排定一次尾随推送（限频窗口内多次更新只排一次）
@@ -60,16 +63,18 @@ const scanNotifyMinGap = 500 * time.Millisecond
 // 不限频会向浏览器灌入成百上千条消息造成前端卡顿
 const recordNotifyMinGap = 250 * time.Millisecond
 
-// newTask 创建一个初始状态为 queued 的任务
-func newTask(kind Kind, chatID int64, chatTitle string) *task {
+// newTask 创建一个初始状态为 queued 的任务；spec 携带 ChatID/Filters/MessageID
+func newTask(kind Kind, spec downloader.HistorySpec, chatTitle string) *task {
 	return &task{
 		id:        generateID(),
 		kind:      kind,
-		chatID:    chatID,
+		chatID:    spec.ChatID,
 		chatTitle: chatTitle,
 		createdAt: time.Now(),
 		done:      make(chan struct{}),
 		status:    StatusQueued,
+		filters:   spec.Filters,
+		messageID: spec.MessageID,
 	}
 }
 
@@ -81,6 +86,10 @@ func (t *task) markDone() {
 // taskFromRow 是 ToDTO 的逆操作，从持久化行重建进程重启后的内存任务；
 // done/closeOnce 属于进程本地状态，无法持久化，此处总是全新初始化
 func taskFromRow(row *store.TaskRow) *task {
+	var filters downloader.HistoryFilters
+	if row.Filters != "" {
+		_ = json.Unmarshal([]byte(row.Filters), &filters) // 解析失败退化为不过滤
+	}
 	return &task{
 		id:            row.ID,
 		kind:          Kind(row.Kind),
@@ -95,6 +104,8 @@ func taskFromRow(row *store.TaskRow) *task {
 		expectedTotal: row.ExpectedTotal,
 		scanCursor:    row.ScanCursor,
 		attempts:      row.Attempts,
+		filters:       filters,
+		messageID:     row.MessageID,
 		stats: downloader.Stats{
 			Total:          row.Total,
 			Downloaded:     row.Downloaded,
@@ -106,11 +117,30 @@ func taskFromRow(row *store.TaskRow) *task {
 	}
 }
 
+// filtersJSON 返回过滤器的 JSON 序列化（零值返回空串，落库为 NULL）
+func (t *task) filtersJSON() string {
+	if t.filters.IsZero() {
+		return ""
+	}
+	data, err := json.Marshal(t.filters)
+	if err != nil {
+		return ""
+	}
+	return string(data)
+}
+
 // ToDTO 加锁返回任务状态的值拷贝快照
 func (t *task) ToDTO() TaskDTO {
 	t.mu.Lock()
 	defer t.mu.Unlock()
+	var filters *downloader.HistoryFilters
+	if !t.filters.IsZero() {
+		f := t.filters
+		filters = &f
+	}
 	return TaskDTO{
+		Filters:         filters,
+		MessageID:       t.messageID,
 		ID:              t.id,
 		Kind:            string(t.kind),
 		ChatID:          t.chatID,

--- a/internal/store/history.go
+++ b/internal/store/history.go
@@ -22,8 +22,8 @@ const (
 func (s *Store) UpsertHistoryStart(ctx context.Context, rec *HistoryRecord) error {
 	const q = `
 INSERT INTO history (task_id, chat_id, chat_title, message_id, media_type, file_name, file_path,
-                      file_size, mime_type, status, reason, created_at, finished_at, unique_id)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, NULL, ?)
+                      file_size, mime_type, status, reason, created_at, finished_at, unique_id, album_id)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?, NULL, ?, ?)
 ON CONFLICT(chat_id, message_id) DO UPDATE SET
   task_id    = excluded.task_id,
   chat_title = excluded.chat_title,
@@ -36,7 +36,8 @@ ON CONFLICT(chat_id, message_id) DO UPDATE SET
   reason     = NULL,
   created_at = excluded.created_at,
   finished_at = NULL,
-  unique_id  = COALESCE(NULLIF(excluded.unique_id, ''), history.unique_id)
+  unique_id  = COALESCE(NULLIF(excluded.unique_id, ''), history.unique_id),
+  album_id   = excluded.album_id
 WHERE history.status NOT IN ('completed', 'failed')
    OR (history.status = 'failed' AND history.reason = '` + HistoryReasonInterrupted + `')`
 
@@ -48,7 +49,7 @@ WHERE history.status NOT IN ('completed', 'failed')
 	_, err := s.execContext(ctx, q,
 		nullString(rec.TaskID), rec.ChatID, nullString(rec.ChatTitle), rec.MessageID,
 		rec.MediaType, rec.FileName, rec.FilePath, rec.FileSize, nullString(rec.MimeType),
-		rec.Status, timeToUnix(createdAt), nullString(rec.UniqueID),
+		rec.Status, timeToUnix(createdAt), nullString(rec.UniqueID), rec.AlbumID,
 	)
 	if err != nil {
 		return fmt.Errorf("写入下载历史失败: %w", err)

--- a/internal/store/recorder.go
+++ b/internal/store/recorder.go
@@ -40,6 +40,7 @@ func NewRecorder(s *Store) func(context.Context, downloader.RecordEvent) {
 				MimeType:  evt.Media.MimeType,
 				Status:    status,
 				UniqueID:  evt.Media.UniqueID,
+				AlbumID:   evt.Media.AlbumID,
 			})
 		case downloader.RecordCompleted:
 			_ = s.UpdateHistoryResult(ctx, evt.Media.ChatID, evt.Media.MessageID, HistoryStatusCompleted, "", evt.FilePath)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -48,7 +48,9 @@ CREATE TABLE IF NOT EXISTS tasks (
   downloaded_size INTEGER DEFAULT 0,
   expected_total  INTEGER NOT NULL DEFAULT 0,
   scan_cursor     INTEGER NOT NULL DEFAULT 0,
-  attempts        INTEGER NOT NULL DEFAULT 0
+  attempts        INTEGER NOT NULL DEFAULT 0,
+  filters         TEXT,
+  message_id      INTEGER NOT NULL DEFAULT 0
 );
 CREATE INDEX IF NOT EXISTS idx_tasks_status     ON tasks(status);
 CREATE INDEX IF NOT EXISTS idx_tasks_created_at ON tasks(created_at DESC);
@@ -69,6 +71,7 @@ CREATE TABLE IF NOT EXISTS history (
   created_at  INTEGER NOT NULL,
   finished_at INTEGER,
   unique_id   TEXT,
+  album_id    INTEGER NOT NULL DEFAULT 0,
   UNIQUE(chat_id, message_id)
 );
 CREATE INDEX IF NOT EXISTS idx_history_media_type ON history(media_type);
@@ -142,6 +145,8 @@ func migrateTasksTable(ctx context.Context, db *sql.DB) error {
 		`expected_total INTEGER NOT NULL DEFAULT 0`,
 		`scan_cursor INTEGER NOT NULL DEFAULT 0`,
 		`attempts INTEGER NOT NULL DEFAULT 0`,
+		`filters TEXT`,
+		`message_id INTEGER NOT NULL DEFAULT 0`,
 	} {
 		if err := addColumnIfMissing(ctx, db, "tasks", col); err != nil {
 			return err
@@ -157,6 +162,9 @@ func migrateTasksTable(ctx context.Context, db *sql.DB) error {
 // migrateHistoryTable 为既有库补充 unique_id 列与索引，并将旧版中断原因归一为常量
 func migrateHistoryTable(ctx context.Context, db *sql.DB) error {
 	if err := addColumnIfMissing(ctx, db, "history", `unique_id TEXT`); err != nil {
+		return err
+	}
+	if err := addColumnIfMissing(ctx, db, "history", `album_id INTEGER NOT NULL DEFAULT 0`); err != nil {
 		return err
 	}
 	if _, err := db.ExecContext(ctx, `CREATE INDEX IF NOT EXISTS idx_history_unique_id ON history(unique_id)`); err != nil {

--- a/internal/store/tasks.go
+++ b/internal/store/tasks.go
@@ -19,14 +19,14 @@ func (s *Store) CreateTask(ctx context.Context, t *TaskRow) error {
 	const q = `
 INSERT INTO tasks (id, kind, chat_id, chat_title, status, created_at, started_at, finished_at,
                     error, total, downloaded, failed, skipped, total_size, downloaded_size, expected_total,
-                    scan_cursor, attempts)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+                    scan_cursor, attempts, filters, message_id)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
 
 	_, err := s.execContext(ctx, q,
 		t.ID, t.Kind, t.ChatID, t.ChatTitle, t.Status, timeToUnix(t.CreatedAt),
 		timePtrToUnix(t.StartedAt), timePtrToUnix(t.FinishedAt), nullString(t.Error),
 		t.Total, t.Downloaded, t.Failed, t.Skipped, t.TotalSize, t.DownloadedSize, t.ExpectedTotal,
-		t.ScanCursor, t.Attempts,
+		t.ScanCursor, t.Attempts, nullString(t.Filters), t.MessageID,
 	)
 	if err != nil {
 		return fmt.Errorf("创建任务失败: %w", err)
@@ -84,7 +84,7 @@ func (s *Store) ListTasks(ctx context.Context) ([]*TaskRow, error) {
 	const q = `
 SELECT id, kind, chat_id, chat_title, status, created_at, started_at, finished_at,
        error, total, downloaded, failed, skipped, total_size, downloaded_size, expected_total,
-       scan_cursor, attempts
+       scan_cursor, attempts, filters, message_id
 FROM tasks ORDER BY created_at DESC`
 
 	rows, err := s.db.QueryContext(ctx, q)
@@ -112,7 +112,7 @@ func (s *Store) GetTask(ctx context.Context, id string) (*TaskRow, error) {
 	const q = `
 SELECT id, kind, chat_id, chat_title, status, created_at, started_at, finished_at,
        error, total, downloaded, failed, skipped, total_size, downloaded_size, expected_total,
-       scan_cursor, attempts
+       scan_cursor, attempts, filters, message_id
 FROM tasks WHERE id = ?`
 
 	row := s.db.QueryRowContext(ctx, q, id)
@@ -129,22 +129,23 @@ FROM tasks WHERE id = ?`
 // scanTaskRow 从单行结果解析出 TaskRow
 func scanTaskRow(row scanner) (*TaskRow, error) {
 	var (
-		t                     TaskRow
-		createdAt             int64
-		startedAt, finishedAt sql.NullInt64
-		errMsg, chatTitle     sql.NullString
+		t                          TaskRow
+		createdAt                  int64
+		startedAt, finishedAt      sql.NullInt64
+		errMsg, chatTitle, filters sql.NullString
 	)
 
 	if err := row.Scan(
 		&t.ID, &t.Kind, &t.ChatID, &chatTitle, &t.Status, &createdAt, &startedAt, &finishedAt,
 		&errMsg, &t.Total, &t.Downloaded, &t.Failed, &t.Skipped, &t.TotalSize, &t.DownloadedSize,
-		&t.ExpectedTotal, &t.ScanCursor, &t.Attempts,
+		&t.ExpectedTotal, &t.ScanCursor, &t.Attempts, &filters, &t.MessageID,
 	); err != nil {
 		return nil, err
 	}
 
 	t.ChatTitle = chatTitle.String
 	t.Error = errMsg.String
+	t.Filters = filters.String
 	t.CreatedAt = unixToTime(createdAt)
 	t.StartedAt = nullInt64ToTimePtr(startedAt)
 	t.FinishedAt = nullInt64ToTimePtr(finishedAt)

--- a/internal/store/types.go
+++ b/internal/store/types.go
@@ -20,8 +20,10 @@ type TaskRow struct {
 	TotalSize      int64
 	DownloadedSize int64
 	ExpectedTotal  int64
-	ScanCursor     int64 // 历史扫描游标（最后已扫描页的最旧 message_id），0 = 从最新开始
-	Attempts       int   // 自动重试已消耗的次数
+	ScanCursor     int64  // 历史扫描游标（最后已扫描页的最旧 message_id），0 = 从最新开始
+	Attempts       int    // 自动重试已消耗的次数
+	Filters        string // 任务级过滤器 JSON（downloader.HistoryFilters），空 = 不过滤
+	MessageID      int64  // 单消息下载任务的目标消息 id，0 = 整聊天历史任务
 }
 
 // 任务状态常量，取值与 internal/queue 的 Status 保持一致（queue 为唯一词汇源）
@@ -50,6 +52,7 @@ type HistoryRecord struct {
 	CreatedAt  time.Time
 	FinishedAt *time.Time
 	UniqueID   string // TDLib remote file unique_id，跨聊天稳定，用于内容级去重
+	AlbumID    int64  // Telegram 相册 id（media_album_id），0 = 不属于相册
 }
 
 // 下载历史状态常量，取值与 downloader.RecordStatus 保持一致

--- a/internal/telegram/client.go
+++ b/internal/telegram/client.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -156,6 +157,7 @@ func newClient(cfg *config.Config, log *logger.Logger, chatID int64) *Client {
 	c.downloader.SetDownloadFunc(c.DownloadFile)
 	c.downloader.SetPauseFunc(c.pauseDownloadFile)
 	c.downloader.SetClassifyByType(!cfg.Download.DisableClassifyByType)
+	c.downloader.SetSaveMetadata(cfg.Download.SaveMetadata)
 	return c
 }
 
@@ -704,6 +706,53 @@ func isNoMoreChats(err error) bool {
 
 // extractMediaInfo 从消息内容提取下载所需的媒体信息（无媒体返回 nil）
 func (c *Client) extractMediaInfo(m *tdclient.Message) *downloader.MediaInfo {
+	mi := c.extractMediaFile(m)
+	if mi == nil {
+		return nil
+	}
+	mi.AlbumID = int64(m.MediaAlbumId)
+	mi.Caption = captionText(m.Content)
+	mi.SenderID = senderID(m.SenderId)
+	return mi
+}
+
+// captionText 提取消息内容的 caption 文本（无 caption 的类型返回空串）
+func captionText(content tdclient.MessageContent) string {
+	var ft *tdclient.FormattedText
+	switch c := content.(type) {
+	case *tdclient.MessagePhoto:
+		ft = c.Caption
+	case *tdclient.MessageVideo:
+		ft = c.Caption
+	case *tdclient.MessageDocument:
+		ft = c.Caption
+	case *tdclient.MessageAnimation:
+		ft = c.Caption
+	case *tdclient.MessageAudio:
+		ft = c.Caption
+	case *tdclient.MessageVoiceNote:
+		ft = c.Caption
+	}
+	if ft == nil {
+		return ""
+	}
+	return ft.Text
+}
+
+// senderID 提取发送者的 user/chat id
+func senderID(sender tdclient.MessageSender) int64 {
+	switch s := sender.(type) {
+	case *tdclient.MessageSenderUser:
+		return s.UserId
+	case *tdclient.MessageSenderChat:
+		return s.ChatId
+	default:
+		return 0
+	}
+}
+
+// extractMediaFile 按内容类型提取媒体文件信息（不含相册/caption/发送者等消息级字段）
+func (c *Client) extractMediaFile(m *tdclient.Message) *downloader.MediaInfo {
 	if m == nil || m.Content == nil {
 		return nil
 	}
@@ -917,27 +966,109 @@ func (c *Client) unregisterProgress(fileID int32) {
 	c.trackMu.Unlock()
 }
 
-// DownloadHistoryMedia 下载聊天历史中的全部媒体
-// historyCountFilters 与 extractMediaInfo 支持的媒体类型一一对应
-var historyCountFilters = []tdclient.SearchMessagesFilter{
-	&tdclient.SearchMessagesFilterPhoto{},
-	&tdclient.SearchMessagesFilterVideo{},
-	&tdclient.SearchMessagesFilterDocument{},
-	&tdclient.SearchMessagesFilterAudio{},
-	&tdclient.SearchMessagesFilterVoiceNote{},
-	&tdclient.SearchMessagesFilterAnimation{},
+// historyCountFilters 将媒体类型映射到服务端计数过滤器，与 extractMediaInfo 支持的类型一一对应
+var historyCountFilters = map[string]tdclient.SearchMessagesFilter{
+	mediaTypePhoto:     &tdclient.SearchMessagesFilterPhoto{},
+	mediaTypeVideo:     &tdclient.SearchMessagesFilterVideo{},
+	mediaTypeDocument:  &tdclient.SearchMessagesFilterDocument{},
+	mediaTypeAudio:     &tdclient.SearchMessagesFilterAudio{},
+	mediaTypeVoice:     &tdclient.SearchMessagesFilterVoiceNote{},
+	mediaTypeAnimation: &tdclient.SearchMessagesFilterAnimation{},
+}
+
+// ResolvedTarget 是 t.me 链接/公开用户名的解析结果；MessageID 非 0 表示指向单条消息
+type ResolvedTarget struct {
+	ChatID    int64  `json:"chat_id"`
+	Title     string `json:"chat_title"`
+	MessageID int64  `json:"message_id,omitempty"`
+}
+
+// ResolveTarget 解析下载目标：支持 @用户名、t.me/<name>、t.me/<name>/<msg>、
+// t.me/c/<id>/<msg> 及带 https:// 前缀的等价形式。私有链接要求当前账号可访问该聊天。
+func (c *Client) ResolveTarget(ctx context.Context, input string) (ResolvedTarget, error) {
+	td := c.client()
+	if td == nil {
+		return ResolvedTarget{}, errors.New("TDLib 未连接")
+	}
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return ResolvedTarget{}, errors.New("目标不能为空")
+	}
+
+	normalized := strings.TrimPrefix(strings.TrimPrefix(input, "https://"), "http://")
+	if path, ok := strings.CutPrefix(normalized, "t.me/"); ok {
+		if strings.HasPrefix(path, "+") || strings.HasPrefix(path, "joinchat/") {
+			return ResolvedTarget{}, errors.New("暂不支持邀请链接，请先加入该聊天后从列表选择")
+		}
+		// 含消息序号（t.me/<name>/<msg> 或 t.me/c/<id>/<msg>）走消息链接解析
+		if strings.Contains(path, "/") {
+			return c.resolveMessageLink(ctx, td, "https://t.me/"+path)
+		}
+		return c.resolvePublicChat(ctx, td, path)
+	}
+	return c.resolvePublicChat(ctx, td, strings.TrimPrefix(input, "@"))
+}
+
+// resolveMessageLink 经 GetMessageLinkInfo 解析消息链接
+func (c *Client) resolveMessageLink(ctx context.Context, td *tdclient.Client, url string) (ResolvedTarget, error) {
+	info, err := tdCall(ctx, metadataTimeout, func(cc context.Context) (*tdclient.MessageLinkInfo, error) {
+		return td.GetMessageLinkInfo(cc, &tdclient.GetMessageLinkInfoRequest{Url: url})
+	})
+	if err != nil {
+		return ResolvedTarget{}, fmt.Errorf("解析消息链接失败: %w", err)
+	}
+	if info.ChatId == 0 {
+		return ResolvedTarget{}, errors.New("无法访问该链接指向的聊天（可能需要先加入）")
+	}
+	target := ResolvedTarget{ChatID: info.ChatId}
+	if info.Message != nil {
+		target.MessageID = info.Message.Id
+	}
+	if chat, err := tdCall(ctx, metadataTimeout, func(cc context.Context) (*tdclient.Chat, error) {
+		return td.GetChat(cc, &tdclient.GetChatRequest{ChatId: info.ChatId})
+	}); err == nil {
+		target.Title = chat.Title
+	}
+	return target, nil
+}
+
+// resolvePublicChat 按公开用户名解析聊天
+func (c *Client) resolvePublicChat(ctx context.Context, td *tdclient.Client, username string) (ResolvedTarget, error) {
+	if username == "" {
+		return ResolvedTarget{}, errors.New("用户名不能为空")
+	}
+	chat, err := tdCall(ctx, metadataTimeout, func(cc context.Context) (*tdclient.Chat, error) {
+		return td.SearchPublicChat(cc, &tdclient.SearchPublicChatRequest{Username: username})
+	})
+	if err != nil {
+		return ResolvedTarget{}, fmt.Errorf("找不到公开聊天 @%s: %w", username, err)
+	}
+	return ResolvedTarget{ChatID: chat.Id, Title: chat.Title}, nil
 }
 
 // CountHistoryMedia 统计聊天历史中可下载媒体的总数（服务端近似值）。
+// mediaTypes 非空时只统计选中的类型；日期/大小过滤无法在服务端预估，结果为上估。
 // 单个过滤器失败仅跳过；全部失败返回错误，调用方回退为未知总数。
-func (c *Client) CountHistoryMedia(ctx context.Context, chatID int64) (int64, error) {
+func (c *Client) CountHistoryMedia(ctx context.Context, chatID int64, mediaTypes []string) (int64, error) {
 	td := c.client()
 	if td == nil {
 		return 0, errors.New("TDLib 未连接")
 	}
+	selected := make([]tdclient.SearchMessagesFilter, 0, len(historyCountFilters))
+	if len(mediaTypes) == 0 {
+		for _, f := range historyCountFilters {
+			selected = append(selected, f)
+		}
+	} else {
+		for _, t := range mediaTypes {
+			if f, ok := historyCountFilters[t]; ok {
+				selected = append(selected, f)
+			}
+		}
+	}
 	var total int64
 	succeeded := 0
-	for _, filter := range historyCountFilters {
+	for _, filter := range selected {
 		f := filter
 		cnt, err := tdCall(ctx, metadataTimeout, func(cc context.Context) (*tdclient.Count, error) {
 			return td.GetChatMessageCount(cc, &tdclient.GetChatMessageCountRequest{
@@ -1035,6 +1166,17 @@ func (c *Client) DownloadHistoryMedia(ctx context.Context, spec downloader.Histo
 		return nil
 	}
 
+	// 单消息任务（t.me 消息链接）：只下载指定消息，不扫描历史
+	if spec.MessageID != 0 {
+		err := c.downloadSingleHistoryMessage(ctx, td, spec, dispatch)
+		wg.Wait()
+		if err != nil {
+			return err
+		}
+		c.downloader.PrintStats()
+		return nil
+	}
+
 	// 恢复任务先补下被重启清扫的中断行：这些消息比游标更新，续扫不会再经过
 	if len(spec.RetryMessageIDs) > 0 {
 		if err := c.retryInterruptedMessages(ctx, td, spec, dispatch); err != nil {
@@ -1067,7 +1209,7 @@ func (c *Client) DownloadHistoryMedia(ctx context.Context, spec downloader.Histo
 			}
 			emptyStreak = 0
 
-			media, lastMsgID := c.extractBatchMedia(pageMsgs, taskID)
+			media, lastMsgID, pastDateFrom := c.extractBatchMedia(pageMsgs, taskID, spec.Filters)
 			fromMsgID = lastMsgID // 推进到本页最旧消息
 			scannedMessages += int64(len(pageMsgs))
 			foundMedia += int64(len(media))
@@ -1080,6 +1222,10 @@ func (c *Client) DownloadHistoryMedia(ctx context.Context, spec downloader.Histo
 				if err := dispatch(m); err != nil {
 					return err
 				}
+			}
+			if pastDateFrom {
+				c.logger.Info("历史扫描已越过起始日期，提前结束")
+				return nil
 			}
 
 			if time.Since(lastScanLog) >= scanLogInterval {
@@ -1120,7 +1266,8 @@ func (c *Client) retryInterruptedMessages(
 			c.logger.Warn("补下中断媒体失败（消息 %d 可能已删除）: %v", msgID, err)
 			continue
 		}
-		if media := c.extractMediaInfo(msg); media != nil {
+		if media := c.extractMediaInfo(msg); media != nil &&
+			spec.Filters.Match(media.MediaType, int64(msg.Date), media.FileSize) {
 			media.TaskID = spec.TaskID
 			batch = append(batch, media)
 		}
@@ -1132,6 +1279,29 @@ func (c *Client) retryInterruptedMessages(
 		}
 	}
 	return nil
+}
+
+// downloadSingleHistoryMessage 下载单条消息的媒体（t.me 消息链接任务）
+func (c *Client) downloadSingleHistoryMessage(
+	ctx context.Context, td *tdclient.Client, spec downloader.HistorySpec,
+	dispatch func(*downloader.MediaInfo) error,
+) error {
+	msg, err := tdCall(ctx, metadataTimeout, func(cc context.Context) (*tdclient.Message, error) {
+		return td.GetMessage(cc, &tdclient.GetMessageRequest{ChatId: spec.ChatID, MessageId: spec.MessageID})
+	})
+	if err != nil {
+		return fmt.Errorf("获取消息 %d 失败: %w", spec.MessageID, err)
+	}
+	media := c.extractMediaInfo(msg)
+	if media == nil {
+		return fmt.Errorf("消息 %d 不包含可下载的媒体", spec.MessageID)
+	}
+	if !spec.Filters.Match(media.MediaType, int64(msg.Date), media.FileSize) {
+		return fmt.Errorf("消息 %d 的媒体被任务过滤器排除", spec.MessageID)
+	}
+	media.TaskID = spec.TaskID
+	c.downloader.PlanBatch([]*downloader.MediaInfo{media})
+	return dispatch(media)
 }
 
 // reportScanProgress 上报历史扫描进度与游标；未注册回调（CLI 模式）或无任务 ID 时静默
@@ -1165,17 +1335,24 @@ func fetchHistoryPage(ctx context.Context, td *tdclient.Client, chatID, fromMsgI
 	return pageMsgs, nil
 }
 
-// extractBatchMedia 从一页历史消息中提取媒体信息并打上任务ID，
-// 同时返回本页最旧消息ID供调用方推进下一页起点
-func (c *Client) extractBatchMedia(msgs []*tdclient.Message, taskID string) (media []*downloader.MediaInfo, lastMsgID int64) {
+// extractBatchMedia 从一页历史消息中提取媒体信息、按任务过滤器筛选并打上任务ID；
+// 返回本页最旧消息ID供调用方推进下一页起点，以及整页是否已早于 DateFrom（可提前停止翻页：
+// 历史页按新到旧返回，整页更旧则更早的页必然全部越界）
+func (c *Client) extractBatchMedia(
+	msgs []*tdclient.Message, taskID string, filters downloader.HistoryFilters,
+) (media []*downloader.MediaInfo, lastMsgID int64, pastDateFrom bool) {
+	pastDateFrom = len(msgs) > 0 && filters.DateFrom != 0
 	for _, m := range msgs {
-		if mi := c.extractMediaInfo(m); mi != nil {
+		if int64(m.Date) >= filters.DateFrom {
+			pastDateFrom = false
+		}
+		if mi := c.extractMediaInfo(m); mi != nil && filters.Match(mi.MediaType, int64(m.Date), mi.FileSize) {
 			mi.TaskID = taskID
 			media = append(media, mi)
 		}
 		lastMsgID = m.Id
 	}
-	return media, lastMsgID
+	return media, lastMsgID, pastDateFrom
 }
 
 // awaitNextHistoryPage 处理获取到空历史页时的退避逻辑：

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"tg-down/internal/downloader"
 	"tg-down/internal/queue"
 	"tg-down/internal/store"
 	"tg-down/internal/telegram"
@@ -31,6 +32,7 @@ func (s *Server) routes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/settings/classify", s.handleSettingsClassify)
 	mux.HandleFunc("GET /api/tasks", s.handleTasksList)
 	mux.HandleFunc("POST /api/tasks", s.handleTasksCreate)
+	mux.HandleFunc("POST /api/resolve", s.handleResolve)
 	mux.HandleFunc("POST /api/tasks/{id}/cancel", s.handleTaskCancel)
 	mux.HandleFunc("POST /api/tasks/{id}/retry", s.handleTaskRetry)
 	mux.HandleFunc("GET /api/download/settings", s.handleDownloadSettings)
@@ -239,6 +241,12 @@ func (s *Server) handleTasksCreate(w http.ResponseWriter, r *http.Request) {
 	var body struct {
 		Kind   string `json:"kind"`
 		ChatID int64  `json:"chat_id"`
+		// Filters 是任务级过滤条件（仅 history 任务生效；monitor 在 v2.0 忽略过滤器）
+		Filters downloader.HistoryFilters `json:"filters"`
+		// MessageID 非 0 时创建单消息下载任务（来自 /api/resolve 的消息链接解析）
+		MessageID int64 `json:"message_id"`
+		// ChatTitle 可选；公开频道可能不在缓存聊天列表中，由解析结果直接携带标题
+		ChatTitle string `json:"chat_title"`
 	}
 	if !s.decode(w, r, &body) {
 		return
@@ -248,15 +256,43 @@ func (s *Server) handleTasksCreate(w http.ResponseWriter, r *http.Request) {
 		s.writeError(w, http.StatusBadRequest, "kind 必须为 history 或 monitor")
 		return
 	}
+	if msg := body.Filters.Validate(); msg != "" {
+		s.writeError(w, http.StatusBadRequest, msg)
+		return
+	}
 	if !s.requireReady(w) {
 		return
 	}
-	dto, err := s.queue.Enqueue(kind, body.ChatID, s.chatTitle(body.ChatID))
+	title := body.ChatTitle
+	if title == "" {
+		title = s.chatTitle(body.ChatID)
+	}
+	spec := downloader.HistorySpec{ChatID: body.ChatID, Filters: body.Filters, MessageID: body.MessageID}
+	dto, err := s.queue.Enqueue(kind, spec, title)
 	if err != nil {
 		s.writeError(w, http.StatusConflict, err.Error())
 		return
 	}
 	s.writeJSON(w, dto)
+}
+
+// handleResolve 解析 t.me 链接 / @用户名为聊天与可选消息 id，供前端确认后创建任务
+func (s *Server) handleResolve(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Input string `json:"input"`
+	}
+	if !s.decode(w, r, &body) {
+		return
+	}
+	if !s.requireReady(w) {
+		return
+	}
+	target, err := s.client.ResolveTarget(r.Context(), body.Input)
+	if err != nil {
+		s.writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	s.writeJSON(w, target)
 }
 
 func (s *Server) handleTaskCancel(w http.ResponseWriter, r *http.Request) {

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -497,6 +497,33 @@
         <div class="cmd-select"><select id="cmdChat"></select></div>
         <button class="btn-accent" onclick="enqueueTask('history', cmdChatId(), this)">下载历史媒体</button>
         <button class="btn-tint" onclick="enqueueTask('monitor', cmdChatId(), this)">开启监控</button>
+        <button class="btn-ghost" id="filterToggle" onclick="toggleFilterPanel()">过滤器</button>
+      </div>
+
+      <div class="cmd-bar">
+        <div class="cmd-search" style="flex:1">
+          <input class="bare-input" id="cmdLink" type="text" placeholder="粘贴 t.me 链接或 @用户名（消息链接只下载该条消息）…" />
+        </div>
+        <button class="btn-tint" onclick="resolveAndEnqueue(this)">解析并下载</button>
+      </div>
+
+      <div class="card" id="filterPanel" style="display:none;padding:14px 16px;margin-bottom:14px">
+        <div style="display:flex;flex-wrap:wrap;gap:14px;align-items:center">
+          <span class="meta">媒体类型（不勾选 = 全部）:</span>
+          <label><input type="checkbox" class="ft-type" value="photo"> 图片</label>
+          <label><input type="checkbox" class="ft-type" value="video"> 视频</label>
+          <label><input type="checkbox" class="ft-type" value="document"> 文档</label>
+          <label><input type="checkbox" class="ft-type" value="animation"> 动图</label>
+          <label><input type="checkbox" class="ft-type" value="audio"> 音频</label>
+          <label><input type="checkbox" class="ft-type" value="voice"> 语音</label>
+        </div>
+        <div style="display:flex;flex-wrap:wrap;gap:14px;align-items:center;margin-top:10px">
+          <label class="meta">起始日期 <input type="date" id="ftDateFrom"></label>
+          <label class="meta">结束日期 <input type="date" id="ftDateTo"></label>
+          <label class="meta">单文件上限(MB) <input type="number" id="ftMaxSize" min="0" step="1" style="width:80px"></label>
+          <button class="btn-ghost" onclick="clearFilters()">清空</button>
+          <span class="meta">过滤器对新提交的历史下载任务生效</span>
+        </div>
       </div>
 
       <div class="ov-grid">
@@ -712,6 +739,7 @@ const NAV_ITEMS = [
 ];
 const HISTORY_TYPES = ["photo", "video", "document", "animation", "audio", "voice"];
 const TASK_KIND_LABEL = { history: "历史下载", monitor: "实时监控" };
+const MEDIA_TYPE_LABEL = { photo: "图片", video: "视频", document: "文档", animation: "动图", audio: "音频", voice: "语音" };
 const TASK_STATUS_LABEL = { queued: "排队中", running: "下载中", completed: "已完成", failed: "失败", canceled: "已取消" };
 const HISTORY_STATUS = {
   downloading: ["下载中", "pill-run"],
@@ -1137,9 +1165,70 @@ async function enqueueTask(kind, chatId, b) {
   if (!chatId) return toast("请先选择聊天");
   if (b) b.disabled = true;
   try {
-    await api("/api/tasks", { kind, chat_id: chatId });
+    const body = { kind, chat_id: chatId };
+    if (kind === "history") {
+      const f = collectFilters();
+      if (f) body.filters = f;
+    }
+    await api("/api/tasks", body);
     if (kind === "monitor") { target = chatId; renderMonitor(); renderChats(); }
     toast(kind === "history" ? "已提交历史下载" : "已开始实时监控");
+    loadTasks();
+  } catch (e) { toast(e.message); }
+  finally { if (b) b.disabled = false; }
+}
+
+/* ---- 任务过滤器 ---- */
+function toggleFilterPanel() {
+  const p = $("filterPanel");
+  p.style.display = p.style.display === "none" ? "" : "none";
+}
+function clearFilters() {
+  document.querySelectorAll(".ft-type").forEach(c => { c.checked = false; });
+  $("ftDateFrom").value = ""; $("ftDateTo").value = ""; $("ftMaxSize").value = "";
+}
+// collectFilters 读取面板状态，返回过滤器对象（无过滤时返回 null）
+function collectFilters() {
+  const types = [...document.querySelectorAll(".ft-type:checked")].map(c => c.value);
+  const f = {};
+  if (types.length) f.media_types = types;
+  const from = $("ftDateFrom").value, to = $("ftDateTo").value;
+  if (from) f.date_from = Math.floor(new Date(from + "T00:00:00").getTime() / 1000);
+  if (to) f.date_to = Math.floor(new Date(to + "T23:59:59").getTime() / 1000);
+  const mb = parseFloat($("ftMaxSize").value);
+  if (mb > 0) f.max_file_size = Math.floor(mb * 1024 * 1024);
+  return Object.keys(f).length ? f : null;
+}
+// filterChips 生成任务卡上的过滤/单消息标记文本
+function filterChips(t) {
+  const bits = [];
+  if (t.message_id) bits.push("单条消息");
+  const f = t.filters;
+  if (f) {
+    if (f.media_types && f.media_types.length) bits.push("类型:" + f.media_types.map(x => MEDIA_TYPE_LABEL[x] || x).join("/"));
+    if (f.date_from) bits.push("自 " + new Date(f.date_from * 1000).toLocaleDateString());
+    if (f.date_to) bits.push("至 " + new Date(f.date_to * 1000).toLocaleDateString());
+    if (f.max_file_size) bits.push("≤" + Math.round(f.max_file_size / 1048576) + "MB");
+  }
+  return bits.length ? ` · ${bits.join(" · ")}` : "";
+}
+
+/* ---- t.me 链接解析 ---- */
+async function resolveAndEnqueue(b) {
+  const input = ($("cmdLink").value || "").trim();
+  if (!input) return toast("请输入 t.me 链接或 @用户名");
+  if (b) b.disabled = true;
+  try {
+    const target = await api("/api/resolve", { input });
+    const scope = target.message_id ? "该条消息" : "整个聊天的历史媒体";
+    if (!confirm(`将下载「${target.chat_title || ("ID " + target.chat_id)}」的${scope}，确认？`)) return;
+    const body = { kind: "history", chat_id: target.chat_id, chat_title: target.chat_title || "" };
+    if (target.message_id) body.message_id = target.message_id;
+    const f = collectFilters();
+    if (f) body.filters = f;
+    await api("/api/tasks", body);
+    $("cmdLink").value = "";
+    toast("已提交下载任务");
     loadTasks();
   } catch (e) { toast(e.message); }
   finally { if (b) b.disabled = false; }
@@ -1251,7 +1340,7 @@ function renderTaskList() {
       <div class="task-row-top">
         <div class="task-row-main">
           <b title="${escapeAttr(t.chat_title || "")}">${escapeHtml(t.chat_title) || ("ID " + t.chat_id)}</b>
-          <small>${escapeHtml(TASK_KIND_LABEL[t.kind] || t.kind)} · ${escapeHtml(TASK_STATUS_LABEL[t.status] || t.status)}${expectedText}${scanText}</small>
+          <small>${escapeHtml(TASK_KIND_LABEL[t.kind] || t.kind)} · ${escapeHtml(TASK_STATUS_LABEL[t.status] || t.status)}${expectedText}${scanText}${escapeHtml(filterChips(t))}</small>
         </div>
         <div class="task-row-side">
           <span class="pct">${progressText}</span>


### PR DESCRIPTION
v2.0 里程碑 3/5（base=M2）：

- 任务级过滤器：媒体类型/日期区间/大小上限，JSON 持久化，恢复/重试均携带；整页早于起始日期提前停扫；Web 过滤面板与任务卡标记
- t.me 链接：POST /api/resolve 解析 @用户名/链接；消息链接创建单消息任务（expected_total=1）
- 相册聚合：album_<id> 子目录 + history.album_id
- 元数据 sidecar：download.save_metadata 开启后写 <文件>.json

验证：过滤器穿透/持久化/重试携带单测通过。