### PR TITLE
v2.0 M4: 体验（定时下载 / 完成通知）

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -141,7 +141,7 @@ func runWeb(cfg *config.Config, log *logger.Logger, addr string) error {
 	ctx, cancel := setupSignalHandling(log)
 	defer cancel()
 
-	if err := web.New(client, st, log, addr, cfg.Queue.MaxConcurrentTasks, cfg.Queue.AutoRetryCount()).Run(ctx); err != nil {
+	if err := web.New(client, st, log, addr, cfg).Run(ctx); err != nil {
 		return fmt.Errorf("Web 服务运行失败: %w", err)
 	}
 	return nil

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -35,3 +35,8 @@ queue:
 # 持久化存储配置
 store:
   path: "./tg-down.db"  # SQLite 数据库文件路径
+
+# 任务完成通知（任务完成/最终失败时触发，取消不通知）
+notify:
+  telegram_self: false  # 向自己的 Saved Messages 发送通知消息
+  webhook_url: ""       # 非空时向该地址 POST 任务 JSON

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,6 +54,15 @@ type Config struct {
 	Retry    RetryConfig    `yaml:"retry"`
 	Queue    QueueConfig    `yaml:"queue"`
 	Store    StoreConfig    `yaml:"store"`
+	Notify   NotifyConfig   `yaml:"notify"`
+}
+
+// NotifyConfig 任务完成通知配置
+type NotifyConfig struct {
+	// TelegramSelf 为 true 时任务终结（完成/最终失败）向自己的 Saved Messages 发消息
+	TelegramSelf bool `yaml:"telegram_self"`
+	// WebhookURL 非空时任务终结向该地址 POST JSON
+	WebhookURL string `yaml:"webhook_url"`
 }
 
 // APIConfig Telegram API配置
@@ -225,6 +234,17 @@ func loadFromEnv(config *Config) {
 	loadRetryConfig(config)
 	loadQueueConfig(config)
 	loadStoreConfig(config)
+	loadNotifyConfig(config)
+}
+
+// loadNotifyConfig 加载通知配置
+func loadNotifyConfig(config *Config) {
+	if v := os.Getenv("NOTIFY_TELEGRAM_SELF"); v != "" {
+		config.Notify.TelegramSelf = v == "1" || strings.EqualFold(v, "true")
+	}
+	if v := os.Getenv("NOTIFY_WEBHOOK_URL"); v != "" {
+		config.Notify.WebhookURL = v
+	}
 }
 
 // loadAPIConfig 加载API配置

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -1,0 +1,97 @@
+// Package notify 在任务终结（完成/最终失败）时向 Telegram Saved Messages
+// 和/或 webhook 发送通知；全部 best-effort，失败仅记日志，绝不影响任务流程。
+package notify
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"tg-down/internal/logger"
+	"tg-down/internal/queue"
+)
+
+// notifyTimeout 是单次通知（Telegram/webhook）的超时上限
+const notifyTimeout = 10 * time.Second
+
+// Notifier 任务终结通知器；两个通道均可选
+type Notifier struct {
+	selfSend   func(ctx context.Context, text string) error // nil = 不发 Telegram
+	webhookURL string                                       // 空 = 不发 webhook
+	logger     *logger.Logger
+	httpClient *http.Client
+}
+
+// New 创建通知器；selfSend 为 nil 且 webhookURL 为空时返回 nil（调用方据此跳过接线）
+func New(selfSend func(ctx context.Context, text string) error, webhookURL string, log *logger.Logger) *Notifier {
+	if selfSend == nil && webhookURL == "" {
+		return nil
+	}
+	return &Notifier{
+		selfSend:   selfSend,
+		webhookURL: webhookURL,
+		logger:     log,
+		httpClient: &http.Client{Timeout: notifyTimeout},
+	}
+}
+
+// TaskFinished 异步发送任务终结通知（按任务粒度，绝不按文件）
+func (n *Notifier) TaskFinished(dto queue.TaskDTO) {
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), notifyTimeout)
+		defer cancel()
+		if n.selfSend != nil {
+			if err := n.selfSend(ctx, formatMessage(dto)); err != nil {
+				n.logger.Warn("Telegram 通知发送失败: %v", err)
+			}
+		}
+		if n.webhookURL != "" {
+			if err := n.postWebhook(ctx, dto); err != nil {
+				n.logger.Warn("webhook 通知发送失败: %v", err)
+			}
+		}
+	}()
+}
+
+// formatMessage 生成 Saved Messages 通知文本
+func formatMessage(dto queue.TaskDTO) string {
+	title := dto.ChatTitle
+	if title == "" {
+		title = fmt.Sprintf("ID %d", dto.ChatID)
+	}
+	switch dto.Status {
+	case string(queue.StatusCompleted):
+		return fmt.Sprintf("✅ Tg-Down 任务完成：%s\n下载 %d，跳过 %d，失败 %d",
+			title, dto.Stats.Downloaded, dto.Stats.Skipped, dto.Stats.Failed)
+	default:
+		return fmt.Sprintf("❌ Tg-Down 任务失败：%s\n%s", title, dto.Error)
+	}
+}
+
+// postWebhook 向 webhookURL POST 任务 JSON（外层包 event 字段）
+func (n *Notifier) postWebhook(ctx context.Context, dto queue.TaskDTO) error {
+	payload, err := json.Marshal(map[string]any{
+		"event": "task_finished",
+		"task":  dto,
+	})
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, n.webhookURL, bytes.NewReader(payload))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := n.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		return fmt.Errorf("webhook 返回 %s", resp.Status)
+	}
+	return nil
+}

--- a/internal/queue/manager.go
+++ b/internal/queue/manager.go
@@ -48,6 +48,7 @@ type Manager struct {
 	order       []*task // 插入顺序（最早在前），List() 据此反转为最新优先
 	monitorTask *task
 	onChange    func(*TaskDTO)
+	onTerminal  func(TaskDTO) // 任务终结通知（completed/最终 failed，取消与自动重试不触发）
 	runCtx      context.Context
 
 	monitorMu sync.Mutex // 串行化 monitor 切换，保证同一时刻至多一个 monitor 任务在运行
@@ -175,6 +176,24 @@ func (m *Manager) SetOnChange(fn func(*TaskDTO)) {
 	m.mu.Unlock()
 }
 
+// SetOnTerminal 设置任务终结回调：completed 与自动重试耗尽后的最终 failed 触发，
+// canceled 与重试中的中间失败不触发；按任务粒度调用
+func (m *Manager) SetOnTerminal(fn func(TaskDTO)) {
+	m.mu.Lock()
+	m.onTerminal = fn
+	m.mu.Unlock()
+}
+
+// fireTerminal 触发任务终结回调（若已注册）
+func (m *Manager) fireTerminal(t *task) {
+	m.mu.Lock()
+	fn := m.onTerminal
+	m.mu.Unlock()
+	if fn != nil {
+		fn(t.ToDTO())
+	}
+}
+
 // Run 启动 history worker 池与记录持久化 writer，阻塞直至 ctx 取消；取消后停止接受新任务执行，
 // 所有运行中任务的 ctx 均派生自 ctx，会随之自动取消。启动时一次性消费 loadTasks 收集的待恢复任务。
 func (m *Manager) Run(ctx context.Context) {
@@ -194,6 +213,7 @@ func (m *Manager) Run(ctx context.Context) {
 	}()
 
 	go m.persistLoop(ctx)
+	go m.runScheduler(ctx)
 
 	var wg sync.WaitGroup
 	for i := 0; i < m.maxConcurrentTasks; i++ {
@@ -413,6 +433,9 @@ func (m *Manager) runHistoryTask(ctx context.Context, t *task) {
 	if retryScheduled {
 		m.scheduleRetry(t, attempt, err)
 		return // 任务未终结，不 markDone
+	}
+	if !canceled {
+		m.fireTerminal(t) // completed 或最终 failed
 	}
 	t.markDone()
 }

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -775,3 +775,57 @@ func TestEnqueue_FiltersFlowThroughSpecAndRetry(t *testing.T) {
 		t.Fatalf("Retry 未携带过滤器: %+v", retrySpecs)
 	}
 }
+
+// TestFireDueSchedules 验证定时计划：到期触发入队并更新 last_run；
+// 未到期/运行中重叠时不重复触发
+func TestFireDueSchedules(t *testing.T) {
+	fc := newFakeClient()
+	st := newTestStore(t)
+	m := NewManager(fc, st, logger.New(logger.LevelError), 1, 0)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+	go m.Run(ctx)
+
+	if err := st.CreateSchedule(ctx, &store.ScheduleRow{
+		ID: "s1", ChatID: 7, ChatTitle: "chat-7", IntervalMin: 10, Enabled: true,
+		CreatedAt: time.Now(),
+	}); err != nil {
+		t.Fatalf("CreateSchedule() error = %v", err)
+	}
+
+	// last_run 为空 → 立即到期触发
+	m.fireDueSchedules(ctx)
+	deadline := time.Now().Add(testWaitTimeout)
+	var taskID string
+	for taskID == "" {
+		for _, dto := range m.List() {
+			if dto.ChatID == 7 && dto.Kind == string(KindHistory) {
+				taskID = dto.ID
+			}
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("定时计划未触发任务")
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	rows, _ := st.ListSchedules(ctx)
+	if len(rows) != 1 || rows[0].LastRun == nil {
+		t.Fatalf("last_run 未更新: %+v", rows[0])
+	}
+
+	// 任务仍在运行且未到期 → 不重复触发
+	m.fireDueSchedules(ctx)
+	count := 0
+	for _, dto := range m.List() {
+		if dto.ChatID == 7 && dto.Kind == string(KindHistory) {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("到期前重复触发: %d 个任务", count)
+	}
+
+	fc.release(taskID)
+	waitForStatus(t, m, taskID, StatusCompleted, testWaitTimeout)
+}

--- a/internal/queue/scheduler.go
+++ b/internal/queue/scheduler.go
@@ -1,0 +1,64 @@
+package queue
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"tg-down/internal/downloader"
+)
+
+const (
+	// scheduleTickInterval 是定时计划的巡检周期
+	scheduleTickInterval = time.Minute
+	// MinScheduleIntervalMin 是定时计划允许的最小间隔（分钟），供 API 校验复用
+	MinScheduleIntervalMin = 10
+)
+
+// runScheduler 周期性巡检定时计划，到期的计划触发一次历史下载任务；
+// 随 Manager.Run 的 ctx 退出
+func (m *Manager) runScheduler(ctx context.Context) {
+	ticker := time.NewTicker(scheduleTickInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			m.fireDueSchedules(ctx)
+		}
+	}
+}
+
+// fireDueSchedules 触发所有到期的计划。先记录触发时间再入队：
+// 若因同聊天已有任务被去重拒绝，也不会在下个 tick 立即热重试
+func (m *Manager) fireDueSchedules(ctx context.Context) {
+	rows, err := m.store.ListSchedules(ctx)
+	if err != nil {
+		m.logger.Warn("查询定时计划失败: %v", err)
+		return
+	}
+	now := time.Now()
+	for _, r := range rows {
+		if !r.Enabled {
+			continue
+		}
+		if r.LastRun != nil && now.Sub(*r.LastRun) < time.Duration(r.IntervalMin)*time.Minute {
+			continue
+		}
+		if err := m.store.TouchScheduleLastRun(ctx, r.ID, now); err != nil {
+			m.logger.Warn("更新定时计划触发时间失败: %v", err)
+		}
+		var filters downloader.HistoryFilters
+		if r.Filters != "" {
+			_ = json.Unmarshal([]byte(r.Filters), &filters) // 解析失败退化为不过滤
+		}
+		spec := downloader.HistorySpec{ChatID: r.ChatID, Filters: filters}
+		if _, err := m.Enqueue(KindHistory, spec, r.ChatTitle); err != nil {
+			// 常见于同聊天已有排队/运行中的任务，跳过本次触发
+			m.logger.Info("定时计划 %s（聊天 %d）本次触发跳过: %v", r.ID, r.ChatID, err)
+			continue
+		}
+		m.logger.Info("定时计划 %s 已触发聊天 %d 的历史下载", r.ID, r.ChatID)
+	}
+}

--- a/internal/store/schedules.go
+++ b/internal/store/schedules.go
@@ -1,0 +1,106 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"time"
+)
+
+// ScheduleRow 表示 schedules 表中的一条定时下载计划
+type ScheduleRow struct {
+	ID          string     `json:"id"`
+	ChatID      int64      `json:"chat_id"`
+	ChatTitle   string     `json:"chat_title,omitempty"`
+	IntervalMin int        `json:"interval_min"`
+	Filters     string     `json:"filters,omitempty"` // downloader.HistoryFilters JSON
+	Enabled     bool       `json:"enabled"`
+	LastRun     *time.Time `json:"last_run,omitempty"`
+	CreatedAt   time.Time  `json:"created_at"`
+}
+
+// CreateSchedule 插入一条定时计划
+func (s *Store) CreateSchedule(ctx context.Context, r *ScheduleRow) error {
+	const q = `
+INSERT INTO schedules (id, chat_id, chat_title, interval_min, filters, enabled, last_run, created_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
+
+	_, err := s.execContext(ctx, q,
+		r.ID, r.ChatID, nullString(r.ChatTitle), r.IntervalMin, nullString(r.Filters),
+		r.Enabled, timePtrToUnix(r.LastRun), timeToUnix(r.CreatedAt),
+	)
+	if err != nil {
+		return fmt.Errorf("创建定时计划失败: %w", err)
+	}
+	return nil
+}
+
+// ListSchedules 返回全部定时计划，按创建时间倒序
+func (s *Store) ListSchedules(ctx context.Context) ([]*ScheduleRow, error) {
+	const q = `
+SELECT id, chat_id, chat_title, interval_min, filters, enabled, last_run, created_at
+FROM schedules ORDER BY created_at DESC`
+
+	rows, err := s.db.QueryContext(ctx, q)
+	if err != nil {
+		return nil, fmt.Errorf("查询定时计划失败: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var items []*ScheduleRow
+	for rows.Next() {
+		r, err := scanScheduleRow(rows)
+		if err != nil {
+			return nil, fmt.Errorf("解析定时计划失败: %w", err)
+		}
+		items = append(items, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("遍历定时计划失败: %w", err)
+	}
+	return items, nil
+}
+
+// DeleteSchedule 删除定时计划
+func (s *Store) DeleteSchedule(ctx context.Context, id string) error {
+	res, err := s.execContext(ctx, `DELETE FROM schedules WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("删除定时计划失败: %w", err)
+	}
+	return checkRowsAffected(res, "定时计划", id)
+}
+
+// SetScheduleEnabled 启用/停用定时计划
+func (s *Store) SetScheduleEnabled(ctx context.Context, id string, enabled bool) error {
+	res, err := s.execContext(ctx, `UPDATE schedules SET enabled = ? WHERE id = ?`, enabled, id)
+	if err != nil {
+		return fmt.Errorf("更新定时计划失败: %w", err)
+	}
+	return checkRowsAffected(res, "定时计划", id)
+}
+
+// TouchScheduleLastRun 记录定时计划的最近触发时间
+func (s *Store) TouchScheduleLastRun(ctx context.Context, id string, at time.Time) error {
+	res, err := s.execContext(ctx, `UPDATE schedules SET last_run = ? WHERE id = ?`, at.Unix(), id)
+	if err != nil {
+		return fmt.Errorf("更新定时计划触发时间失败: %w", err)
+	}
+	return checkRowsAffected(res, "定时计划", id)
+}
+
+func scanScheduleRow(row scanner) (*ScheduleRow, error) {
+	var (
+		r                  ScheduleRow
+		chatTitle, filters sql.NullString
+		lastRun            sql.NullInt64
+		createdAt          int64
+	)
+	if err := row.Scan(&r.ID, &r.ChatID, &chatTitle, &r.IntervalMin, &filters, &r.Enabled, &lastRun, &createdAt); err != nil {
+		return nil, err
+	}
+	r.ChatTitle = chatTitle.String
+	r.Filters = filters.String
+	r.LastRun = nullInt64ToTimePtr(lastRun)
+	r.CreatedAt = unixToTime(createdAt)
+	return &r, nil
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -79,6 +79,17 @@ CREATE INDEX IF NOT EXISTS idx_history_chat_id    ON history(chat_id);
 CREATE INDEX IF NOT EXISTS idx_history_status     ON history(status);
 CREATE INDEX IF NOT EXISTS idx_history_created_at ON history(created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_history_unique_id  ON history(unique_id);
+
+CREATE TABLE IF NOT EXISTS schedules (
+  id           TEXT PRIMARY KEY,
+  chat_id      INTEGER NOT NULL,
+  chat_title   TEXT,
+  interval_min INTEGER NOT NULL,
+  filters      TEXT,
+  enabled      INTEGER NOT NULL DEFAULT 1,
+  last_run     INTEGER,
+  created_at   INTEGER NOT NULL
+);
 `
 
 // Store 是基于 SQLite 的持久化句柄

--- a/internal/telegram/client.go
+++ b/internal/telegram/client.go
@@ -976,6 +976,38 @@ var historyCountFilters = map[string]tdclient.SearchMessagesFilter{
 	mediaTypeAnimation: &tdclient.SearchMessagesFilterAnimation{},
 }
 
+// SendSelfMessage 向自己的 Saved Messages 发送一条文本消息（用于任务完成通知）
+func (c *Client) SendSelfMessage(ctx context.Context, text string) error {
+	td := c.client()
+	if td == nil {
+		return errors.New("TDLib 未连接")
+	}
+	me, err := tdCall(ctx, metadataTimeout, func(cc context.Context) (*tdclient.User, error) {
+		return td.GetMe(cc)
+	})
+	if err != nil {
+		return fmt.Errorf("获取当前用户失败: %w", err)
+	}
+	chat, err := tdCall(ctx, metadataTimeout, func(cc context.Context) (*tdclient.Chat, error) {
+		return td.CreatePrivateChat(cc, &tdclient.CreatePrivateChatRequest{UserId: me.Id})
+	})
+	if err != nil {
+		return fmt.Errorf("打开 Saved Messages 失败: %w", err)
+	}
+	_, err = tdCall(ctx, metadataTimeout, func(cc context.Context) (*tdclient.Message, error) {
+		return td.SendMessage(cc, &tdclient.SendMessageRequest{
+			ChatId: chat.Id,
+			InputMessageContent: &tdclient.InputMessageText{
+				Text: &tdclient.FormattedText{Text: text},
+			},
+		})
+	})
+	if err != nil {
+		return fmt.Errorf("发送通知消息失败: %w", err)
+	}
+	return nil
+}
+
 // ResolvedTarget 是 t.me 链接/公开用户名的解析结果；MessageID 非 0 表示指向单条消息
 type ResolvedTarget struct {
 	ChatID    int64  `json:"chat_id"`

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -43,6 +43,10 @@ func (s *Server) routes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /api/media/resume-all", s.handleMediaResumeAll)
 	mux.HandleFunc("GET /api/history", s.handleHistoryList)
 	mux.HandleFunc("GET /api/history/stats", s.handleHistoryStats)
+	mux.HandleFunc("GET /api/schedules", s.handleSchedulesList)
+	mux.HandleFunc("POST /api/schedules", s.handleSchedulesCreate)
+	mux.HandleFunc("DELETE /api/schedules/{id}", s.handleScheduleDelete)
+	mux.HandleFunc("POST /api/schedules/{id}/toggle", s.handleScheduleToggle)
 }
 
 func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
@@ -310,6 +314,91 @@ func (s *Server) handleTaskRetry(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	s.writeJSON(w, dto)
+}
+
+/* ---- 定时下载计划 ---- */
+
+func (s *Server) handleSchedulesList(w http.ResponseWriter, r *http.Request) {
+	rows, err := s.store.ListSchedules(r.Context())
+	if err != nil {
+		s.writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if rows == nil {
+		rows = []*store.ScheduleRow{}
+	}
+	s.writeJSON(w, rows)
+}
+
+func (s *Server) handleSchedulesCreate(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		ChatID      int64                     `json:"chat_id"`
+		IntervalMin int                       `json:"interval_min"`
+		Filters     downloader.HistoryFilters `json:"filters"`
+		ChatTitle   string                    `json:"chat_title"`
+	}
+	if !s.decode(w, r, &body) {
+		return
+	}
+	if body.ChatID == 0 {
+		s.writeError(w, http.StatusBadRequest, "chat_id 不能为空")
+		return
+	}
+	if body.IntervalMin < queue.MinScheduleIntervalMin {
+		s.writeError(w, http.StatusBadRequest,
+			fmt.Sprintf("间隔不能小于 %d 分钟", queue.MinScheduleIntervalMin))
+		return
+	}
+	if msg := body.Filters.Validate(); msg != "" {
+		s.writeError(w, http.StatusBadRequest, msg)
+		return
+	}
+	title := body.ChatTitle
+	if title == "" {
+		title = s.chatTitle(body.ChatID)
+	}
+	filtersJSON := ""
+	if !body.Filters.IsZero() {
+		if data, err := json.Marshal(body.Filters); err == nil {
+			filtersJSON = string(data)
+		}
+	}
+	row := &store.ScheduleRow{
+		ID:          fmt.Sprintf("s%d", time.Now().UnixNano()),
+		ChatID:      body.ChatID,
+		ChatTitle:   title,
+		IntervalMin: body.IntervalMin,
+		Filters:     filtersJSON,
+		Enabled:     true,
+		CreatedAt:   time.Now(),
+	}
+	if err := s.store.CreateSchedule(r.Context(), row); err != nil {
+		s.writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	s.writeJSON(w, row)
+}
+
+func (s *Server) handleScheduleDelete(w http.ResponseWriter, r *http.Request) {
+	if err := s.store.DeleteSchedule(r.Context(), r.PathValue("id")); err != nil {
+		s.writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	s.writeOK(w)
+}
+
+func (s *Server) handleScheduleToggle(w http.ResponseWriter, r *http.Request) {
+	var body struct {
+		Enabled bool `json:"enabled"`
+	}
+	if !s.decode(w, r, &body) {
+		return
+	}
+	if err := s.store.SetScheduleEnabled(r.Context(), r.PathValue("id"), body.Enabled); err != nil {
+		s.writeError(w, http.StatusNotFound, err.Error())
+		return
+	}
+	s.writeOK(w)
 }
 
 func (s *Server) handleDownloadSettings(w http.ResponseWriter, _ *http.Request) {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -15,8 +15,10 @@ import (
 	"sync"
 	"time"
 
+	"tg-down/internal/config"
 	"tg-down/internal/downloader"
 	"tg-down/internal/logger"
+	"tg-down/internal/notify"
 	"tg-down/internal/queue"
 	"tg-down/internal/store"
 	"tg-down/internal/telegram"
@@ -88,15 +90,23 @@ type Server struct {
 // errAuthAborted 标记用户主动中止登录（返回上一步），区别于真实认证失败
 var errAuthAborted = errors.New("登录已被用户中止")
 
-// New 创建 Web 管理端，内部以 maxConcurrentTasks/autoRetry 构建任务队列管理器
-func New(client *telegram.Client, st *store.Store, log *logger.Logger, addr string, maxConcurrentTasks, autoRetry int) *Server {
+// New 创建 Web 管理端：按配置构建任务队列管理器并接线完成通知
+func New(client *telegram.Client, st *store.Store, log *logger.Logger, addr string, cfg *config.Config) *Server {
 	if addr == "" {
 		addr = DefaultAddr
+	}
+	q := queue.NewManager(client, st, log, cfg.Queue.MaxConcurrentTasks, cfg.Queue.AutoRetryCount())
+	var selfSend func(context.Context, string) error
+	if cfg.Notify.TelegramSelf {
+		selfSend = client.SendSelfMessage
+	}
+	if n := notify.New(selfSend, cfg.Notify.WebhookURL, log); n != nil {
+		q.SetOnTerminal(n.TaskFinished)
 	}
 	return &Server{
 		client:       client,
 		store:        st,
-		queue:        queue.NewManager(client, st, log, maxConcurrentTasks, autoRetry),
+		queue:        q,
 		logger:       log,
 		addr:         addr,
 		token:        os.Getenv(webTokenEnv),

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -584,6 +584,17 @@
       <div class="card task-list" id="mediaList"><div class="empty">暂无排队或下载中的媒体</div></div>
       <div class="queue-sub">批量任务<span id="batchCountText"></span></div>
       <div class="card task-list" id="taskList"><div class="empty">暂无批量任务</div></div>
+
+      <div class="queue-sub">定时下载<span id="schedCountText"></span></div>
+      <div class="card" style="padding:14px 16px;margin-bottom:12px">
+        <div style="display:flex;flex-wrap:wrap;gap:10px;align-items:center">
+          <div class="cmd-select"><select id="schedChat"></select></div>
+          <label class="meta">间隔(分钟) <input class="num-input" id="schedInterval" type="number" min="10" step="10" value="1440" style="width:90px"></label>
+          <button class="btn-tint" onclick="createSchedule(this)">新建计划</button>
+          <span class="meta">到期自动增量扫描该聊天（沿用概览页过滤器设置）</span>
+        </div>
+      </div>
+      <div class="card task-list" id="schedList"><div class="empty">暂无定时计划</div></div>
     </section>
 
     <!-- ======== 下载历史 ======== -->
@@ -766,8 +777,8 @@ function withToken(path) {
   if (!authToken) return path;
   return path + (path.includes("?") ? "&" : "?") + "token=" + encodeURIComponent(authToken);
 }
-async function api(path, body) {
-  const opt = { method: body === undefined ? "GET" : "POST", headers: {} };
+async function api(path, body, method) {
+  const opt = { method: method || (body === undefined ? "GET" : "POST"), headers: {} };
   if (body !== undefined) {
     opt.headers["Content-Type"] = "application/json";
     opt.body = JSON.stringify(body);
@@ -826,6 +837,9 @@ function showPage(key) {
     loadSettings();
   } else if (key === "chats" && !chats.length) {
     loadChats();
+  } else if (key === "tasks") {
+    loadSchedules();
+    populateSchedChatSelect();
   }
 }
 
@@ -1211,6 +1225,75 @@ function filterChips(t) {
     if (f.max_file_size) bits.push("≤" + Math.round(f.max_file_size / 1048576) + "MB");
   }
   return bits.length ? ` · ${bits.join(" · ")}` : "";
+}
+
+/* ---- 定时下载计划 ---- */
+let schedules = [];
+function populateSchedChatSelect() {
+  const sel = $("schedChat");
+  if (!sel) return;
+  const prev = sel.value;
+  sel.innerHTML = chats.map(c =>
+    `<option value="${c.id}">${escapeHtml(c.title) || ("ID " + c.id)}</option>`).join("")
+    || `<option value="0">暂无聊天</option>`;
+  if ([...sel.options].some(o => o.value === prev)) sel.value = prev;
+}
+async function loadSchedules() {
+  try {
+    schedules = await api("/api/schedules") || [];
+    renderSchedules();
+  } catch (e) {}
+}
+function renderSchedules() {
+  $("schedCountText").textContent = schedules.length ? ` · ${schedules.length} 条` : "";
+  const el = $("schedList");
+  if (!schedules.length) { el.innerHTML = `<div class="empty">暂无定时计划</div>`; return; }
+  el.innerHTML = schedules.map(sc => {
+    const last = sc.last_run ? new Date(sc.last_run).toLocaleString() : "从未";
+    const intervalText = sc.interval_min % 1440 === 0 ? `${sc.interval_min / 1440} 天`
+      : sc.interval_min % 60 === 0 ? `${sc.interval_min / 60} 小时` : `${sc.interval_min} 分钟`;
+    return `<div class="task-row">
+      <div class="task-row-top">
+        <div class="task-row-main">
+          <b title="${escapeAttr(sc.chat_title || "")}">${escapeHtml(sc.chat_title) || ("ID " + sc.chat_id)}</b>
+          <small>每 ${intervalText} · 上次触发: ${escapeHtml(last)}${sc.enabled ? "" : " · 已停用"}</small>
+        </div>
+        <div class="task-row-side">
+          <button class="btn-small" onclick="toggleSchedule('${escapeAttr(sc.id)}', ${!sc.enabled}, this)">${sc.enabled ? "停用" : "启用"}</button>
+          <button class="btn-small" onclick="deleteSchedule('${escapeAttr(sc.id)}', this)">删除</button>
+        </div>
+      </div>
+    </div>`;
+  }).join("");
+}
+async function createSchedule(b) {
+  const chatId = parseInt($("schedChat").value, 10) || 0;
+  if (!chatId) return toast("请先选择聊天");
+  const interval = parseInt($("schedInterval").value, 10) || 0;
+  if (interval < 10) return toast("间隔不能小于 10 分钟");
+  if (b) b.disabled = true;
+  try {
+    const body = { chat_id: chatId, interval_min: interval };
+    const f = collectFilters();
+    if (f) body.filters = f;
+    await api("/api/schedules", body);
+    toast("已创建定时计划");
+    loadSchedules();
+  } catch (e) { toast(e.message); }
+  finally { if (b) b.disabled = false; }
+}
+async function toggleSchedule(id, enabled, b) {
+  if (b) b.disabled = true;
+  try { await api(`/api/schedules/${encodeURIComponent(id)}/toggle`, { enabled }); loadSchedules(); }
+  catch (e) { toast(e.message); }
+  finally { if (b) b.disabled = false; }
+}
+async function deleteSchedule(id, b) {
+  if (!confirm("确认删除该定时计划？")) return;
+  if (b) b.disabled = true;
+  try { await api(`/api/schedules/${encodeURIComponent(id)}`, undefined, "DELETE"); toast("已删除"); loadSchedules(); }
+  catch (e) { toast(e.message); }
+  finally { if (b) b.disabled = false; }
 }
 
 /* ---- t.me 链接解析 ---- */


### PR DESCRIPTION
v2.0 里程碑 4/5（base=M3）：

- 定时下载：schedules 表 + Manager 内置 60s 巡检调度器（先记 last_run 防热循环，同聊天在跑自动跳过）；/api/schedules CRUD 与任务页管理区块
- 完成通知：notify.telegram_self（Saved Messages）与 notify.webhook_url 双通道 best-effort；仅 completed 与自动重试耗尽的最终 failed 触发，按任务粒度

验证：调度器到期触发/重叠跳过单测通过。