### PR TITLE
v2.0 M5: 分发（版本注入 / Docker 多架构 / glibc 修复 #32 / 飞牛适配 / 发布收口）

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+.git
+downloads/
+sessions/
+tg-down
+tg-down.db*
+*.db
+*.db-shm
+*.db-wal
+*.tar.gz
+dist/
+config.yaml
+.env
+*.log
+.vscode/
+.idea/

--- a/.github/WORKFLOWS.md
+++ b/.github/WORKFLOWS.md
@@ -13,20 +13,18 @@
 **包含的作业**:
 
 #### 1. 测试作业 (test)
-- **环境**: Ubuntu Latest, Go 1.21
+- **环境**: Ubuntu Latest, Go 1.25（TDLib 经 `.github/actions/setup-tdlib` 构建并缓存）
 - **步骤**:
   - 检出代码
-  - 设置Go环境
+  - 设置Go环境与 TDLib CGo 环境
   - 下载并验证依赖
   - 运行 `go vet` 静态分析
   - 运行 `go test` 单元测试
   - 构建应用程序
   - 上传构建产物
 
-#### 2. 安全扫描 (security)
-- **工具**: Gosec
-- **功能**: 扫描Go代码中的安全漏洞
-- **输出**: SARIF格式的安全报告
+#### 2. 安全扫描
+- **工具**: Gosec（已集成进 golangci-lint 统一执行）
 
 #### 3. 依赖提交 (dependency-submission)
 - **工具**: go-dependency-submission
@@ -36,18 +34,27 @@
 ### 📦 发布流水线 (`release.yml`)
 
 **触发条件**:
-- 推送版本标签 (格式: `v*`, 如 `v1.0.0`)
+- 推送版本标签 (格式: `v*`, 如 `v2.0.0`)——由维护者手动打 tag
+  （`auto-release.yml` 已改为仅手动触发，不再按提交关键词自动铸版）
 
-**构建矩阵**:
-- **Linux**: AMD64, ARM64
-- **Windows**: AMD64
-- **macOS**: AMD64, ARM64
+**构建矩阵**（CGo + TDLib 无法交叉编译，按平台原生构建）:
+- **Linux AMD64**: 在 `debian:11` 容器内构建（glibc 2.31 基线），发布包自带 `lib/`
+  （OpenSSL 1.1）与 `$ORIGIN/lib` rpath，开箱即用
+- **macOS Apple Silicon (arm64)**: macos-14 原生构建
 
 **发布流程**:
-1. 多平台并行构建
+1. 双平台并行构建（注入 `-X main.version=<tag>`）
 2. 生成SHA256校验和
 3. 创建GitHub Release
 4. 上传所有构建产物和校验和文件
+
+### 🐳 镜像流水线 (`docker.yml`)
+
+**触发条件**: 推送版本标签或手动触发
+
+**构建方式**: amd64（ubuntu-latest）与 arm64（ubuntu-24.04-arm）在各自原生 runner
+构建（禁用 QEMU——模拟编译 TDLib 需数小时），按 digest 推送后合并 manifest，
+产出 `ghcr.io/heartcoolman/tg-down:{latest,v*}` 多架构镜像。
 
 ### 🔍 代码质量检查 (`code-quality.yml`)
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,105 @@
+name: Docker
+
+# 多架构镜像：amd64/arm64 分别在原生 runner 构建（QEMU 模拟编 TDLib 需数小时，禁用），
+# 按 digest 推送后由 manifest job 合并出多架构 tag。
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+env:
+  IMAGE: ghcr.io/${{ github.repository_owner }}/tg-down
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            platform: linux/amd64
+          - runner: ubuntu-24.04-arm
+            platform: linux/arm64
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Prepare platform slug
+        id: plat
+        run: echo "slug=$(echo '${{ matrix.platform }}' | tr '/' '-')" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          build-args: |
+            VERSION=${{ github.ref_type == 'tag' && github.ref_name || 'dev' }}
+          outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=docker-${{ steps.plat.outputs.slug }}
+          cache-to: type=gha,mode=max,scope=docker-${{ steps.plat.outputs.slug }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digest-${{ steps.plat.outputs.slug }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  manifest:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digest-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create multi-arch manifest
+        working-directory: /tmp/digests
+        run: |
+          TAGS="-t ${IMAGE}:latest"
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            TAGS="$TAGS -t ${IMAGE}:${{ github.ref_name }}"
+          fi
+          docker buildx imagetools create $TAGS \
+            $(printf "${IMAGE}@sha256:%s " *)
+
+      - name: Inspect
+        run: docker buildx imagetools inspect "${IMAGE}:latest"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,18 +12,29 @@ env:
 
 jobs:
   # CGo + TDLib 无法交叉编译，故按平台原生构建（仅 linux-amd64 与 darwin-arm64）。
+  # Linux 在 debian:11 容器内构建以钉定 glibc 2.31 基线（修 #32：老系统跑不起新 runner 产物），
+  # 发布包自带 lib/（OpenSSL 1.1），rpath=$ORIGIN/lib，开箱即用。
   build:
     name: Build ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}
+    container: ${{ matrix.container }}
     strategy:
       fail-fast: false
       matrix:
         include:
           - runner: ubuntu-latest
             name: linux-amd64
+            container: debian:11
           - runner: macos-14
             name: darwin-arm64
+            container: ''
     steps:
+      - name: Install build deps (debian:11 container)
+        if: matrix.name == 'linux-amd64'
+        run: |
+          apt-get update
+          apt-get install -y build-essential cmake gperf git curl ca-certificates zlib1g-dev libssl-dev
+
       - name: Checkout code
         uses: actions/checkout@v6
 
@@ -38,10 +49,22 @@ jobs:
       - name: Test
         run: go test ./...
 
-      - name: Build
+      - name: Build (linux, self-contained rpath)
+        if: matrix.name == 'linux-amd64'
+        run: |
+          mkdir -p dist/pkg/lib
+          # 覆盖 setup-tdlib 导出的 rpath：发布包在用户机器上从 $ORIGIN/lib 找动态依赖
+          export CGO_LDFLAGS="-L$HOME/.tdlib/lib -Wl,-rpath,\$ORIGIN/lib -ltdjson_static -ltdjson_private -ltdclient -ltdcore -ltde2e -ltdmtproto -ltdactor -ltdapi -ltddb -ltdsqlite -ltdnet -ltdutils -lstdc++ -lssl -lcrypto -ldl -lz -lm"
+          go build -ldflags "-s -w -X main.version=${GITHUB_REF_NAME}" -o dist/pkg/tg-down ./cmd
+          # 捆绑 OpenSSL 1.1：debian:11 之后的发行版已不再提供该版本
+          cp /usr/lib/x86_64-linux-gnu/libssl.so.1.1 /usr/lib/x86_64-linux-gnu/libcrypto.so.1.1 dist/pkg/lib/
+          objdump -T dist/pkg/tg-down | grep -o 'GLIBC_2\.[0-9.]*' | sort -Vu | tail -1
+
+      - name: Build (macOS)
+        if: matrix.name == 'darwin-arm64'
         run: |
           mkdir -p dist/pkg
-          go build -ldflags="-s -w" -o dist/pkg/tg-down ./cmd
+          go build -ldflags "-s -w -X main.version=${GITHUB_REF_NAME}" -o dist/pkg/tg-down ./cmd
 
       - name: Assemble package
         run: |
@@ -52,7 +75,7 @@ jobs:
           cat > dist/pkg/start.sh <<'EOF'
           #!/bin/bash
           cd "$(dirname "$0")"
-          [ -f config.yaml ] || { echo "请先编辑 config.yaml 填入 API 信息"; exit 1; }
+          [ -d lib ] && export LD_LIBRARY_PATH="$(pwd)/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
           mkdir -p downloads sessions
           chmod +x tg-down
           ./tg-down "$@"
@@ -93,15 +116,16 @@ jobs:
           draft: false
           prerelease: false
           body: |
-            ## 📦 发布包（基于官方 TDLib 引擎）
+            ## 📦 发布包（官方 TDLib 引擎）
 
-            本版本下载引擎已切换为官方 TDLib，提供原生构建的二进制：
+            - **Linux x86_64**: `tg-down-linux-amd64.tar.gz`——在 debian:11 构建（glibc ≥ 2.31 即可运行，
+              覆盖 Debian 11+/Ubuntu 20.04+），OpenSSL 1.1 已随包捆绑于 `lib/`，开箱即用
+            - **macOS Apple Silicon**: `tg-down-darwin-arm64.tar.gz`——需 `brew install openssl@3`
+            - **Docker（推荐，含 arm64）**: `docker pull ghcr.io/heartcoolman/tg-down:latest`，
+              飞牛 fnOS 等 NAS 部署见 README「飞牛OS (fnOS) 部署」
 
-            - **Linux x86_64**: `tg-down-linux-amd64.tar.gz`
-            - **macOS Apple Silicon**: `tg-down-darwin-arm64.tar.gz`
-
-            > CGo 依赖 libtdjson 已静态链入；运行仍需系统 OpenSSL（Linux: libssl3；macOS: `brew install openssl@3`）。
-            > Windows 及交叉编译目标因 CGo 暂不提供，可在对应平台自行 `make tdlib && make build` 构建。
+            > TDLib 已静态链入二进制。Windows 及交叉编译目标因 CGo 暂不提供，
+            > 可在对应平台自行 `make tdlib && make build` 构建。
 
             ### 🚀 使用
             1. 解压，编辑 `config.yaml` 填入 Telegram API 信息（https://my.telegram.org/apps）

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -53,6 +53,7 @@ linters:
             - tg-down/internal/retry
             - tg-down/internal/store
             - tg-down/internal/queue
+            - tg-down/internal/notify
     dupl:
       threshold: 100
     goconst:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,56 @@
+# syntax=docker/dockerfile:1
+# 多阶段构建：builder 编译 TDLib 与 Go 二进制，runtime 仅带运行时依赖。
+# TDLib 层只依赖 scripts/install-tdlib.sh，源码变更不会触发耗时的 TDLib 重建。
+
+FROM golang:1.25-bookworm AS build
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      cmake gperf g++ make git zlib1g-dev libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# TDLib 层（可缓存，约 30-60 分钟）
+COPY scripts/install-tdlib.sh /tmp/install-tdlib.sh
+RUN TDLIB_PREFIX=/opt/tdlib TDLIB_SRC=/tmp/tdlib-src JOBS=$(nproc) \
+      bash /tmp/install-tdlib.sh \
+    && rm -rf /tmp/tdlib-src
+
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+ARG VERSION=dev
+# linux 下 go-tdlib 绑定默认静态链接（tdjson_static），但其列表缺 tde2e 且 -L 指向
+# /usr/local/lib，这里统一补全
+ENV CGO_ENABLED=1 \
+    CGO_CFLAGS="-I/opt/tdlib/include" \
+    CGO_LDFLAGS="-L/opt/tdlib/lib -ltdjson_static -ltdjson_private -ltdclient -ltdcore -ltde2e -ltdmtproto -ltdactor -ltdapi -ltddb -ltdsqlite -ltdnet -ltdutils -lstdc++ -lssl -lcrypto -ldl -lz -lm"
+RUN go build -ldflags "-s -w -X main.version=${VERSION}" -o /out/tg-down ./cmd
+
+FROM debian:12-slim
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      libssl3 zlib1g ca-certificates curl gosu tzdata \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=build /out/tg-down /usr/local/bin/tg-down
+COPY docker/entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+# 纯环境变量运行：无 config.yaml，凭据经 API_ID/API_HASH（或网页登录）注入
+ENV STORE_PATH=/data/tg-down.db \
+    SESSION_DIR=/sessions \
+    DOWNLOAD_PATH=/downloads \
+    TG_DOWN_NO_CONFIG_WRITE=1 \
+    PUID=1000 \
+    PGID=1000
+
+VOLUME ["/downloads", "/sessions", "/data"]
+EXPOSE 8080
+
+# 非回环监听强制 TG_DOWN_WEB_TOKEN（缺失时进程拒绝启动），健康检查带同一 token
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s \
+  CMD curl -fsS "http://127.0.0.1:8080/api/state?token=${TG_DOWN_WEB_TOKEN}" || exit 1
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["--web", "0.0.0.0:8080"]

--- a/Makefile
+++ b/Makefile
@@ -24,10 +24,13 @@ tdlib:
 	@echo "正在构建 TDLib 到 $(TDLIB_PREFIX) ..."
 	@bash scripts/install-tdlib.sh
 
+# 版本号：优先取 git describe，无仓库时为 dev
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+
 # 构建程序（需先 make tdlib 安装 libtdjson）
 build:
-	@echo "正在编译Telegram媒体下载器 (CGo + TDLib)..."
-	@go build -o tg-down ./cmd
+	@echo "正在编译Telegram媒体下载器 (CGo + TDLib, $(VERSION))..."
+	@go build -ldflags "-s -w -X main.version=$(VERSION)" -o tg-down ./cmd
 	@echo "编译完成！"
 
 # 运行程序

--- a/README.md
+++ b/README.md
@@ -41,6 +41,33 @@ make build && ./tg-down
 - **实时进度**：通过 SSE 推送下载统计、进度条与运行日志；
 - 默认仅监听 `127.0.0.1`，浅色/深色自动适配。
 
+## 🐳 Docker 部署
+
+多架构镜像（amd64/arm64）发布于 GHCR：
+
+```bash
+docker run -d --name tg-down \
+  -p 8080:8080 \
+  -e TG_DOWN_WEB_TOKEN=change-me \
+  -e PUID=1000 -e PGID=1000 -e TZ=Asia/Shanghai \
+  -v $PWD/downloads:/downloads -v $PWD/sessions:/sessions -v $PWD/data:/data \
+  ghcr.io/heartcoolman/tg-down:latest
+```
+
+浏览器打开 `http://<主机>:8080?token=change-me` 完成网页登录即可使用。容器为纯环境变量配置
+（`TG_DOWN_NO_CONFIG_WRITE=1`），凭据可留空由网页端填写；`TG_DOWN_WEB_TOKEN` 为必填
+（绑定非回环地址时强制鉴权，缺失将拒绝启动）。
+
+### 飞牛OS (fnOS) 部署
+
+1. 打开 fnOS「Docker」应用 → Compose → 新建项目；
+2. 粘贴 [`docs/fnos/docker-compose.yml`](docs/fnos/docker-compose.yml) 模板，修改
+   `TG_DOWN_WEB_TOKEN` 与卷映射路径（fnOS 存储路径形如 `/vol1/...`，可在文件管理器
+   「复制原始路径」获取；`PUID/PGID` 用 `id` 命令查看）；
+3. 部署后浏览器访问 `http://<NAS地址>:8080?token=<令牌>`，在网页内完成 Telegram
+   验证码/两步验证登录（无需终端交互）；
+4. 下载文件落在映射的 `downloads` 目录，属主为 `PUID:PGID`，可直接经 SMB/相册应用访问。
+
 ## 功能特性
 
 - 🌐 **Web 管理端**: 内置 Apple 风格本地网页，登录/浏览/下载/监控/实时日志一站式管理
@@ -49,9 +76,15 @@ make build && ./tg-down
 - 🚀 **实时监控**: 自动监控群聊新消息并下载媒体文件
 - 📚 **历史下载**: 批量下载群聊（含频道/超级群组）历史消息中的媒体文件
 - 🗂️ **下载任务队列**: 支持依次提交多个聊天的下载任务排队执行，Web 端任务列表可取消/重试
+- 💪 **断点续跑与自动重试**: 进程重启后任务从扫描游标恢复并补下中断文件；失败任务指数退避自动重试
+- 🎯 **内容级去重**: 同一文件被转发到多个聊天只下载一次（按 TDLib unique_id 命中后本地复制）；已存在的文件自动跳过
+- 🎛️ **任务级过滤器**: 按媒体类型/日期区间/单文件大小过滤历史下载
+- 🔗 **t.me 链接下载**: 粘贴链接或 @用户名 直接下载；消息链接精确到单条消息
+- 🖼️ **相册聚合与元数据**: 相册归入 `album_<id>` 子目录；可选写 `<文件>.json` 元数据 sidecar
+- ⏰ **定时下载**: 按间隔自动增量扫描指定聊天
+- 📣 **完成通知**: 任务完成/失败可通知 Saved Messages 或 webhook
 - 📊 **下载统计**: 实时显示下载进度和统计信息
 - 🕘 **下载历史记录**: 按文件持久化下载历史，Web 端支持按媒体类型/聊天/状态/时间筛选、搜索与分页浏览
-- 🎯 **智能去重**: 自动跳过已下载的文件
 - 📁 **分类存储**: 默认按媒体类型在各聊天目录下分子文件夹归档存储，可通过 `disable_classify_by_type` 关闭并恢复旧版扁平布局
 - 🔐 **持久登录**: 首次登录后保存会话，无需重复认证
 - ⚙️ **灵活配置**: 支持YAML配置文件和环境变量配置
@@ -191,6 +224,14 @@ go build -o tg-down ./cmd && ./tg-down
 | `download.path` | 下载路径 | `./downloads` |
 | `download.max_concurrent` | 同时下载的文件数 | `5` |
 | `download.batch_size` | 每批拉取的历史消息数 | `100` |
+| `download.partition_size` | 历史下载在途媒体上限 | `100` |
+| `download.save_metadata` | 随文件写 `<文件>.json` 元数据 | `false` |
+| `download.disable_classify_by_type` | 关闭按媒体类型归档 | `false` |
+| `queue.max_concurrent_tasks` | 同时运行的历史下载任务数 | `1` |
+| `queue.auto_retry` | 任务失败自动重试次数（0 关闭） | `2` |
+| `notify.telegram_self` | 任务终结时通知 Saved Messages | `false` |
+| `notify.webhook_url` | 任务终结时 POST 的 webhook 地址 | 空 |
+| `store.path` | SQLite 数据库文件路径 | `./tg-down.db` |
 | `session.dir` | TDLib 数据库/会话根目录（实际位于 `<dir>/tdlib`） | `./sessions` |
 | `chat.target_id` | 目标群组ID（可选） | `0` |
 | `log.level` | 日志级别 | `info` |
@@ -390,28 +431,53 @@ tg-down/
 
 ## 📋 更新日志
 
-### v3.0.0 (2026-07-01)
-- 🗂️ **下载任务队列**：新增 `internal/queue`，Web 端可依次提交多个聊天的下载任务排队执行（受 `queue.max_concurrent_tasks` 限制），支持取消/重试，取代原单任务模型
-- 💾 **SQLite 持久化**：新增 `internal/store`（基于纯 Go 的 `modernc.org/sqlite`，无 CGo 依赖），任务与下载历史落库持久化
-- 🕘 **下载历史记录**：按文件持久化下载历史，Web 端支持按媒体类型/聊天/状态/时间筛选、搜索与分页浏览
-- 📁 **归档目录调整（默认开启）**：下载文件默认按媒体类型在聊天目录下分子文件夹存放，可通过 `disable_classify_by_type: true` 恢复旧版扁平布局
-- 🔌 **Web API 变更（破坏性）**：新增 `/api/tasks*`、`/api/history*`，取代原 `/api/download*`、`/api/monitor`
-- ⚠️ **行为变更**：旧版扁平目录下已下载的文件，在新版分类目录下会被判定为未下载并重新下载一次（暂未提供迁移工具）
+> 注：早期文档曾把 TDLib 迁移与任务队列标注为 "v2.0.0/v3.0.0"，但这两个版本号从未成为实际
+> git tag——相关功能实际随 v1.4.0 发布。以下条目已按真实 tag 矫正。
 
-### v2.0.0 (2026-07-01)
-- 🔄 **下载引擎切换为官方 TDLib**：经 `github.com/zelenin/go-tdlib`（CGo 绑定 libtdjson）直连官方引擎，原生获得断点续传、CDN 加速、动态分片与优先级调度
-- 🧹 **移除 gotd 依赖**：删除自研 `session`/`floodwait`/`ratelimit` 中间件（认证由 TDLib 数据库持久化，限流/flood-wait 由 TDLib 内部处理）
-- 🧱 **构建变更（破坏性）**：首次需 `make tdlib` 构建安装 TDLib；`make build` 自动设置 CGo 环境
-- 📦 **发布改为原生构建**：CGo 无法交叉编译，仅提供 linux-amd64 与 darwin-arm64；Windows/交叉目标需本地自建
-- ⚠️ **配置变更**：`download.chunk_size`/`max_workers`/`rate_limit.*` 失效（TDLib 自管），保留仅为向后兼容
-- 🎞️ **媒体类型扩展**：历史下载新增视频/动图/音频/语音
+### v2.0.0 (2026-07)
+- 🔄 **可靠性**：任务断点续跑（重启后从持久化扫描游标恢复、自动补下中断文件、监控任务自动恢复）；
+  内容级去重（同一文件转发到多个聊天只下载一次，按 TDLib remote unique_id 命中后本地复制）；
+  任务失败自动重试（`queue.auto_retry`，默认 2 次，指数退避、断点续扫）
+- 🎯 **任务级过滤器**：按媒体类型/日期区间/单文件大小上限过滤历史下载，Web 端过滤面板
+- 🔗 **t.me 链接下载**：粘贴 `t.me` 链接或 `@用户名` 直接下载；消息链接只下载该条消息
+- 🖼️ **相册聚合**：同一相册的文件归入 `album_<id>` 子目录
+- 📝 **元数据 sidecar**：`download.save_metadata` 开启后随文件写 `<文件>.json`（caption/发送者/日期）
+- ⏰ **定时下载**：按间隔自动增量扫描指定聊天（Web 端管理，最小间隔 10 分钟）
+- 📣 **完成通知**：任务完成/最终失败时通知 Saved Messages（`notify.telegram_self`）或 webhook
+- 🐳 **Docker 多架构镜像**：GHCR 发布 amd64/arm64，支持 PUID/PGID/TZ 与纯环境变量配置，
+  含飞牛OS (fnOS) 部署模板
+- 🛠️ **Linux 发布包修复**：改在 debian:11 构建（glibc ≥ 2.31 可运行，修复 #32），
+  OpenSSL 1.1 随包捆绑，开箱即用
+- 🔢 **版本注入**：`--version`、启动横幅与 Web 端页脚显示构建版本
+- ⚠️ **破坏性变更**：
+  - 移除配置项 `download.chunk_size`/`download.max_workers`/`rate_limit.*` 及对应环境变量（加载时警告）
+  - 移除 CLI 交互命令 `check`（监控为 TDLib 推送式，无需手动轮询）
+  - 移除实验性 Rust helper（`TG_DOWN_RUST_CORE*` 环境变量失效）
+  - go-tdlib 升级至 master（TDLib 1.8.64）：会话数据库自动前向迁移，升级后不支持回退旧版本
+  - SQLite schema 自动迁移（新增列/表），升级后数据库不兼容 v1.x
+  - 旧版下载的相册文件在新的 `album_<id>` 路径下会重新下载一次
+
+### v1.5.0 (2026-07-08)
+- 🚿 **扫描/下载流水线化**：历史扫描持续翻页并即时分发下载，`partition_size` 控制在途上限
+- ⭐ **收藏夹支持**：Saved Messages 出现在聊天列表
+- 📊 进度口径与 SSE 限频修复；Web 管理台 v2 增加登出、中止登录与设置页
+
+### v1.4.0 (2026-07-05)
+- 🔄 **下载引擎切换为官方 TDLib**：经 `github.com/zelenin/go-tdlib`（CGo 绑定 libtdjson）直连官方引擎，
+  原生获得断点续传、CDN 加速、动态分片与优先级调度；移除 gotd 及自研 session/floodwait/ratelimit 中间件
+- 🗂️ **下载任务队列**：新增 `internal/queue`，多任务排队执行、取消/重试
+- 💾 **SQLite 持久化**：新增 `internal/store`（纯 Go `modernc.org/sqlite`），任务与下载历史落库
+- 🕘 **下载历史记录**：Web 端按媒体类型/聊天/状态/时间筛选、搜索与分页
+- 📁 **按类型归档（默认开启）**：可用 `disable_classify_by_type: true` 恢复扁平布局
+- 🌐 **Web 管理端**：内置 Apple 风格本地网页（登录/浏览/下载/监控/实时日志）
+- 🧱 **构建变更**：首次需 `make tdlib` 构建安装 TDLib；发布改为原生构建（linux-amd64/darwin-arm64）
 
 ### v1.3.0 (2025-07-29)
 - 🚀 **完全自动化发布**：实现 git push 后自动打包发布的完整流程
 - 📦 **开箱即用打包**：每个发布包包含所有依赖文件，下载后可直接运行
 - 🤖 **智能版本管理**：根据提交信息自动确定版本号提升类型
 - 📋 **完整发布包**：包含可执行文件、配置文件、启动脚本和说明文档
-- 🎯 **一键启动**：Windows 用户双击 start.bat，Linux/macOS 用户运行 ./start.sh
+- 🎯 **一键启动**：Linux/macOS 用户运行 ./start.sh
 - 📚 **详细说明文档**：每个平台包含专门的配置说明和使用指南
 - ⚡ **自动化工作流**：推送到 main 分支自动触发版本检测和发布流程
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -154,7 +154,7 @@ func runWeb(cfg *config.Config, log *logger.Logger, addr string) error {
 	defer cancel()
 
 	if err := web.New(client, st, log, addr, cfg).Run(ctx); err != nil {
-		return fmt.Errorf("Web 服务运行失败: %w", err)
+		return fmt.Errorf("web 服务运行失败: %w", err)
 	}
 	return nil
 }
@@ -222,7 +222,7 @@ func executeMode(
 	case ModeDownloadHistory:
 		return executeDownloadHistory(ctx, client, log, targetChatID)
 	case ModeMonitorNewMessages:
-		return executeMonitorNewMessages(ctx, cancel, client, log, targetChatID)
+		return executeMonitorNewMessages(ctx, cancel, log, targetChatID)
 	case ModeDownloadAndMonitor:
 		return executeDownloadAndMonitor(ctx, client, log, targetChatID)
 	default:
@@ -252,7 +252,7 @@ func executeDownloadHistory(ctx context.Context, client *telegram.Client, log *l
 		return nil
 	}
 	taskID := fmt.Sprintf("cli-history-%d", time.Now().UnixNano())
-	spec := downloader.HistorySpec{ChatID: targetChatID, TaskID: taskID}
+	spec := &downloader.HistorySpec{ChatID: targetChatID, TaskID: taskID}
 	if err := client.DownloadHistoryMedia(ctx, spec); err != nil {
 		if errors.Is(err, context.Canceled) {
 			return nil
@@ -266,14 +266,13 @@ func executeDownloadHistory(ctx context.Context, client *telegram.Client, log *l
 func executeMonitorNewMessages(
 	ctx context.Context,
 	cancel context.CancelFunc,
-	client *telegram.Client,
 	log *logger.Logger,
 	targetChatID int64,
 ) error {
 	log.Info("开始实时监控新消息...")
 	log.Info("实时监控已启动，目标聊天ID: %d", targetChatID)
 
-	startInteractiveMonitoring(ctx, cancel, client, log, targetChatID)
+	startInteractiveMonitoring(ctx, cancel, log, targetChatID)
 	<-ctx.Done()
 	return nil
 }
@@ -285,7 +284,7 @@ func executeDownloadAndMonitor(ctx context.Context, client *telegram.Client, log
 		return nil
 	}
 	taskID := fmt.Sprintf("cli-history-%d", time.Now().UnixNano())
-	spec := downloader.HistorySpec{ChatID: targetChatID, TaskID: taskID}
+	spec := &downloader.HistorySpec{ChatID: targetChatID, TaskID: taskID}
 	if err := client.DownloadHistoryMedia(ctx, spec); err != nil {
 		if errors.Is(err, context.Canceled) {
 			return nil
@@ -302,7 +301,6 @@ func executeDownloadAndMonitor(ctx context.Context, client *telegram.Client, log
 func startInteractiveMonitoring(
 	ctx context.Context,
 	cancel context.CancelFunc,
-	client *telegram.Client,
 	log *logger.Logger,
 	targetChatID int64,
 ) {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -45,7 +45,19 @@ const (
 	MaxModeChoice = 3
 )
 
+// version 由构建时 -ldflags "-X main.version=..." 注入
+var version = "dev"
+
 func main() {
+	telegram.SetAppVersion(version)
+	web.SetVersion(version)
+
+	// 版本信息: tg-down --version
+	if len(os.Args) > 1 && (os.Args[1] == "--version" || os.Args[1] == "-v") {
+		fmt.Printf("tg-down %s\n", version)
+		return
+	}
+
 	// 清除会话: tg-down --clear-session
 	if len(os.Args) > 1 && os.Args[1] == "--clear-session" {
 		clearSessionAndExit()

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+# 容器入口：按 PUID/PGID 修正数据目录属主后降权运行 tg-down。
+# 仅在顶层属主不符时 chown 目录本身（不递归），避免海量 downloads 拖慢启动；
+# 首次启动（标记文件缺失）时对 /sessions /data 做一次递归修正。
+set -euo pipefail
+
+PUID="${PUID:-1000}"
+PGID="${PGID:-1000}"
+
+if ! getent group "$PGID" >/dev/null 2>&1; then
+  groupadd -g "$PGID" tgdown
+fi
+if ! getent passwd "$PUID" >/dev/null 2>&1; then
+  useradd -u "$PUID" -g "$PGID" -M -s /usr/sbin/nologin tgdown
+fi
+
+for dir in /downloads /sessions /data; do
+  mkdir -p "$dir"
+  if [ "$(stat -c '%u:%g' "$dir")" != "$PUID:$PGID" ]; then
+    chown "$PUID:$PGID" "$dir"
+  fi
+done
+
+marker=/data/.ownership-initialized
+if [ ! -f "$marker" ]; then
+  chown -R "$PUID:$PGID" /sessions /data || true
+  gosu "$PUID:$PGID" touch "$marker"
+fi
+
+exec gosu "$PUID:$PGID" tg-down "$@"

--- a/docs/fnos/docker-compose.yml
+++ b/docs/fnos/docker-compose.yml
@@ -1,0 +1,31 @@
+# Tg-Down 飞牛OS (fnOS) 部署模板
+# 使用：fnOS「Docker」应用 → Compose 项目 → 新建 → 粘贴本文件 → 部署，
+# 然后浏览器打开 http://<NAS地址>:8080?token=<你的令牌> 完成 Telegram 网页登录。
+#
+# 必改项：
+#   1. TG_DOWN_WEB_TOKEN —— 访问令牌（必填，缺失容器将拒绝启动）
+#   2. 卷映射左侧路径 —— 按实际存储空间调整（fnOS 惯例为 /vol1/...，
+#      可在文件管理器中「复制原始路径」获取）
+#   3. API_ID / API_HASH —— 可选：也可留空，在网页端登录时填写
+services:
+  tg-down:
+    image: ghcr.io/heartcoolman/tg-down:latest
+    container_name: tg-down
+    ports:
+      - "8080:8080"
+    environment:
+      TG_DOWN_WEB_TOKEN: "change-me"   # 必填：网页访问令牌
+      API_ID: ""                        # 可选：https://my.telegram.org/apps
+      API_HASH: ""                      # 可选
+      PUID: "1000"                      # 文件属主，跑 `id` 查看你的 NAS 用户
+      PGID: "1000"
+      TZ: "Asia/Shanghai"
+      # MAX_CONCURRENT_DOWNLOADS: "5"   # 同时下载的文件数
+      # AUTO_RETRY: "2"                 # 任务失败自动重试次数
+      # SAVE_METADATA: "false"          # 是否写 <文件>.json 元数据
+      # NOTIFY_TELEGRAM_SELF: "false"   # 任务完成时向 Saved Messages 发通知
+    volumes:
+      - /vol1/1000/tg-down/downloads:/downloads
+      - /vol1/1000/tg-down/sessions:/sessions
+      - /vol1/1000/tg-down/data:/data
+    restart: unless-stopped

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -408,8 +408,13 @@ func validateConfig(config *Config) error {
 	return nil
 }
 
-// SaveConfig 保存配置到文件
+// SaveConfig 保存配置到文件。设置 TG_DOWN_NO_CONFIG_WRITE 环境变量时跳过写入
+// （容器等纯环境变量部署场景，配置由 env 提供，不应写回 config.yaml）。
 func (c *Config) SaveConfig(filename string) error {
+	if os.Getenv("TG_DOWN_NO_CONFIG_WRITE") != "" {
+		fmt.Fprintln(os.Stderr, "[配置] TG_DOWN_NO_CONFIG_WRITE 已设置，跳过配置写回")
+		return nil
+	}
 	data, err := yaml.Marshal(c)
 	if err != nil {
 		return fmt.Errorf("序列化配置失败: %w", err)

--- a/internal/downloader/downloader.go
+++ b/internal/downloader/downloader.go
@@ -36,6 +36,13 @@ const (
 	mediaTypeAudio     = "audio"
 	mediaTypeVoice     = "voice"
 	mediaTypeOther     = "other"
+
+	// 进度状态（MediaProgress.Status）：与 RecordStatus 语义不同，独立成组
+	progressPaused      = "paused"
+	progressDownloading = "downloading"
+
+	// metadataFilePerm 是元数据 sidecar 的文件权限（非敏感内容）
+	metadataFilePerm = 0o644
 )
 
 // MediaInfo 媒体文件信息
@@ -473,7 +480,7 @@ func (d *Downloader) startProgress(media *MediaInfo, filePath string) string {
 	paused := d.allPaused
 	d.controlMu.Unlock()
 	if paused {
-		d.markProgressStatus(key, "paused")
+		d.markProgressStatus(key, progressPaused)
 	}
 	return key
 }
@@ -486,7 +493,7 @@ func (d *Downloader) markProgressStatus(key, status string) {
 		return
 	}
 	p.Status = status
-	p.Paused = status == "paused"
+	p.Paused = status == progressPaused
 	p.UpdatedAt = time.Now()
 }
 
@@ -554,8 +561,8 @@ func (d *Downloader) PauseMedia(ctx context.Context, id string) error {
 	ctrl.cond.Broadcast()
 	ctrl.mu.Unlock()
 
-	wasDownloading := d.progressStatus(id) == "downloading"
-	d.markProgressStatus(id, "paused")
+	wasDownloading := d.progressStatus(id) == progressDownloading
+	d.markProgressStatus(id, progressPaused)
 	if d.pauseFunc != nil && wasDownloading {
 		media := d.mediaByProgressID(id)
 		if media != nil {
@@ -727,55 +734,9 @@ func (d *Downloader) updateStats(downloaded bool, size int64) {
 
 // DownloadMedia 下载媒体文件
 func (d *Downloader) DownloadMedia(ctx context.Context, media *MediaInfo) error {
-	chatDir, fileName, filePath := d.planMediaPath(media)
-	media.FileName = fileName
-
-	// 先做路径安全校验，再创建目录：文件名来自远端消息，
-	// 必须在任何 MkdirAll 之前确认其位于下载根目录内，避免在校验前于任意可写路径建目录。
-	if !d.isSafePath(chatDir, d.downloadPath) || !d.isSafePath(filePath, d.downloadPath) {
-		d.logger.Error("不安全的文件路径: %s", filePath)
-		d.updateStats(false, 0)
-		err := fmt.Errorf("unsafe file path: %s", filePath)
-		d.record(ctx, RecordEvent{Media: media, Status: RecordStarted, FilePath: filePath})
-		d.record(ctx, RecordEvent{Media: media, Status: RecordFailed, FilePath: filePath, Reason: err.Error()})
+	filePath, done, err := d.prepareMediaTarget(ctx, media)
+	if done || err != nil {
 		return err
-	}
-
-	if err := os.MkdirAll(chatDir, DirectoryPermission); err != nil {
-		d.logger.Error("创建目录失败: %v", err)
-		d.updateStats(false, 0)
-		d.record(ctx, RecordEvent{Media: media, Status: RecordStarted, FilePath: chatDir})
-		d.record(ctx, RecordEvent{Media: media, Status: RecordFailed, FilePath: chatDir, Reason: err.Error()})
-		return err
-	}
-
-	// 检查文件是否已存在
-	if _, err := os.Stat(filePath); err == nil {
-		d.logger.Debug("文件已存在，跳过下载: %s", fileName)
-		d.stats.mu.Lock()
-		d.stats.Skipped++
-		d.stats.mu.Unlock()
-		d.record(ctx, RecordEvent{Media: media, Status: RecordSkipped, FilePath: filePath})
-		return nil
-	}
-
-	// 内容级去重：同一 unique_id 已在别处下载完成且源文件仍在，复制而非重新下载；
-	// 源文件已被删除时照常下载（跳过会在用户清理旧文件后静默丢失内容）
-	if media.UniqueID != "" && d.duplicateLookupFunc != nil {
-		if src, ok := d.duplicateLookupFunc(ctx, media.UniqueID); ok && src != "" && src != filePath {
-			if _, err := os.Stat(src); err == nil {
-				if err := copyFile(src, filePath); err == nil {
-					d.logger.Info("内容重复，已从既有文件复制: %s <- %s", fileName, src)
-					d.stats.mu.Lock()
-					d.stats.Skipped++
-					d.stats.mu.Unlock()
-					d.record(ctx, RecordEvent{Media: media, Status: RecordSkipped, FilePath: filePath,
-						Reason: "duplicate of " + src})
-					return nil
-				}
-				d.logger.Warn("去重复制失败，回退为正常下载: %v", err)
-			}
-		}
 	}
 
 	if d.downloadFunc == nil {
@@ -788,6 +749,93 @@ func (d *Downloader) DownloadMedia(ctx context.Context, media *MediaInfo) error 
 	progressKey := d.startProgress(media, filePath)
 	d.record(ctx, RecordEvent{Media: media, Status: RecordStarted, FilePath: filePath})
 
+	if err := d.downloadWithPauseLoop(ctx, media, filePath, progressKey); err != nil {
+		return err
+	}
+
+	actual := d.downloadedBytes(progressKey)
+	if actual <= 0 {
+		actual = media.FileSize
+	}
+	d.logger.Info("下载完成: %s", media.FileName)
+	d.updateStats(true, actual)
+	d.finishProgress(progressKey, media, "completed")
+	d.record(ctx, RecordEvent{Media: media, Status: RecordCompleted, FilePath: filePath, DownloadedSize: actual})
+	d.writeMetadataSidecar(media, filePath)
+	return nil
+}
+
+// prepareMediaTarget 规划目标路径并执行下载前检查（路径安全/建目录/已存在跳过/内容级去重）。
+// done=true 表示无需下载（已跳过或已复制），err 非空表示前置失败（已记录事件）。
+func (d *Downloader) prepareMediaTarget(ctx context.Context, media *MediaInfo) (filePath string, done bool, err error) {
+	chatDir, fileName, filePath := d.planMediaPath(media)
+	media.FileName = fileName
+
+	// 先做路径安全校验，再创建目录：文件名来自远端消息，
+	// 必须在任何 MkdirAll 之前确认其位于下载根目录内，避免在校验前于任意可写路径建目录。
+	if !d.isSafePath(chatDir, d.downloadPath) || !d.isSafePath(filePath, d.downloadPath) {
+		d.logger.Error("不安全的文件路径: %s", filePath)
+		d.updateStats(false, 0)
+		err := fmt.Errorf("unsafe file path: %s", filePath)
+		d.record(ctx, RecordEvent{Media: media, Status: RecordStarted, FilePath: filePath})
+		d.record(ctx, RecordEvent{Media: media, Status: RecordFailed, FilePath: filePath, Reason: err.Error()})
+		return filePath, false, err
+	}
+
+	if err := os.MkdirAll(chatDir, DirectoryPermission); err != nil {
+		d.logger.Error("创建目录失败: %v", err)
+		d.updateStats(false, 0)
+		d.record(ctx, RecordEvent{Media: media, Status: RecordStarted, FilePath: chatDir})
+		d.record(ctx, RecordEvent{Media: media, Status: RecordFailed, FilePath: chatDir, Reason: err.Error()})
+		return filePath, false, err
+	}
+
+	// 检查文件是否已存在
+	if _, err := os.Stat(filePath); err == nil {
+		d.logger.Debug("文件已存在，跳过下载: %s", fileName)
+		d.recordSkip(ctx, media, filePath, "")
+		return filePath, true, nil
+	}
+
+	// 内容级去重：同一 unique_id 已在别处下载完成且源文件仍在，复制而非重新下载；
+	// 源文件已被删除时照常下载（跳过会在用户清理旧文件后静默丢失内容）
+	if d.copyFromDuplicate(ctx, media, filePath) {
+		return filePath, true, nil
+	}
+	return filePath, false, nil
+}
+
+// recordSkip 统计并记录一次跳过事件
+func (d *Downloader) recordSkip(ctx context.Context, media *MediaInfo, filePath, reason string) {
+	d.stats.mu.Lock()
+	d.stats.Skipped++
+	d.stats.mu.Unlock()
+	d.record(ctx, RecordEvent{Media: media, Status: RecordSkipped, FilePath: filePath, Reason: reason})
+}
+
+// copyFromDuplicate 尝试按 unique_id 从既有文件复制；成功返回 true（已记 skipped）
+func (d *Downloader) copyFromDuplicate(ctx context.Context, media *MediaInfo, filePath string) bool {
+	if media.UniqueID == "" || d.duplicateLookupFunc == nil {
+		return false
+	}
+	src, ok := d.duplicateLookupFunc(ctx, media.UniqueID)
+	if !ok || src == "" || src == filePath {
+		return false
+	}
+	if _, err := os.Stat(src); err != nil {
+		return false // 源文件已删，照常下载
+	}
+	if err := copyFile(src, filePath); err != nil {
+		d.logger.Warn("去重复制失败，回退为正常下载: %v", err)
+		return false
+	}
+	d.logger.Info("内容重复，已从既有文件复制: %s <- %s", media.FileName, src)
+	d.recordSkip(ctx, media, filePath, "duplicate of "+src)
+	return true
+}
+
+// downloadWithPauseLoop 执行带暂停/恢复语义的下载循环，直至成功、失败或取消
+func (d *Downloader) downloadWithPauseLoop(ctx context.Context, media *MediaInfo, filePath, progressKey string) error {
 	for {
 		if err := d.waitUntilResumed(ctx, progressKey); err != nil {
 			d.finishCanceled(ctx, progressKey, media, filePath)
@@ -801,41 +849,30 @@ func (d *Downloader) DownloadMedia(ctx context.Context, media *MediaInfo) error 
 		// 若已暂停则释放槽位回到循环等待恢复，避免暂停被 "downloading" 覆盖后静默下载完成。
 		if d.isMediaPaused(progressKey) {
 			d.limiter.release()
-			d.markProgressStatus(progressKey, "paused")
+			d.markProgressStatus(progressKey, progressPaused)
 			continue
 		}
-		d.markProgressStatus(progressKey, "downloading")
+		d.markProgressStatus(progressKey, progressDownloading)
 		d.beginAttempt(progressKey)
-		d.logger.Info("开始下载: %s (大小: %d bytes)", fileName, media.FileSize)
+		d.logger.Info("开始下载: %s (大小: %d bytes)", media.FileName, media.FileSize)
 		err := d.downloadFunc(ctx, media, filePath)
 		d.limiter.release()
 		if err == nil {
-			break
+			return nil
 		}
 		// 暂停诱发的取消不算失败：用 pauseRequestedSince 判定（而非当前 paused 状态），
 		// 以覆盖“暂停后立即恢复”导致 paused 已被清除、错误却仍是暂停取消的竞态。
 		if d.isMediaPaused(progressKey) || d.pauseRequestedSince(progressKey) {
-			d.logger.Info("已暂停下载: %s", fileName)
-			d.markProgressStatus(progressKey, "paused")
+			d.logger.Info("已暂停下载: %s", media.FileName)
+			d.markProgressStatus(progressKey, progressPaused)
 			continue
 		}
-		d.logger.Error("下载失败 %s: %v", fileName, err)
+		d.logger.Error("下载失败 %s: %v", media.FileName, err)
 		d.updateStats(false, 0)
 		d.finishProgress(progressKey, media, "failed")
 		d.record(ctx, RecordEvent{Media: media, Status: RecordFailed, FilePath: filePath, Reason: err.Error()})
 		return err
 	}
-
-	actual := d.downloadedBytes(progressKey)
-	if actual <= 0 {
-		actual = media.FileSize
-	}
-	d.logger.Info("下载完成: %s", fileName)
-	d.updateStats(true, actual)
-	d.finishProgress(progressKey, media, "completed")
-	d.record(ctx, RecordEvent{Media: media, Status: RecordCompleted, FilePath: filePath, DownloadedSize: actual})
-	d.writeMetadataSidecar(media, filePath)
-	return nil
 }
 
 // writeMetadataSidecar 在开关开启时写 <文件>.json 元数据（best-effort，失败仅告警）
@@ -860,7 +897,7 @@ func (d *Downloader) writeMetadataSidecar(media *MediaInfo, filePath string) {
 		d.logger.Warn("序列化元数据失败: %v", err)
 		return
 	}
-	if err := os.WriteFile(filePath+".json", data, 0o644); err != nil { // #nosec G306 -- 元数据非敏感
+	if err := os.WriteFile(filePath+".json", data, metadataFilePerm); err != nil { // #nosec G306 -- 元数据非敏感
 		d.logger.Warn("写入元数据 sidecar 失败: %v", err)
 	}
 }

--- a/internal/downloader/spec.go
+++ b/internal/downloader/spec.go
@@ -61,8 +61,8 @@ func (f HistoryFilters) Match(mediaType string, date, size int64) bool {
 
 // ValidMediaTypes 是 MediaTypes 的合法取值集合
 var ValidMediaTypes = map[string]bool{
-	"photo": true, "video": true, "document": true,
-	"animation": true, "audio": true, "voice": true,
+	mediaTypePhoto: true, mediaTypeVideo: true, mediaTypeDocument: true,
+	mediaTypeAnimation: true, mediaTypeAudio: true, mediaTypeVoice: true,
 }
 
 // Validate 校验过滤器字段合法性，返回首个问题的描述（合法时为空串）

--- a/internal/notify/notify.go
+++ b/internal/notify/notify.go
@@ -39,7 +39,7 @@ func New(selfSend func(ctx context.Context, text string) error, webhookURL strin
 }
 
 // TaskFinished 异步发送任务终结通知（按任务粒度，绝不按文件）
-func (n *Notifier) TaskFinished(dto queue.TaskDTO) {
+func (n *Notifier) TaskFinished(dto *queue.TaskDTO) {
 	go func() {
 		ctx, cancel := context.WithTimeout(context.Background(), notifyTimeout)
 		defer cancel()
@@ -57,7 +57,7 @@ func (n *Notifier) TaskFinished(dto queue.TaskDTO) {
 }
 
 // formatMessage 生成 Saved Messages 通知文本
-func formatMessage(dto queue.TaskDTO) string {
+func formatMessage(dto *queue.TaskDTO) string {
 	title := dto.ChatTitle
 	if title == "" {
 		title = fmt.Sprintf("ID %d", dto.ChatID)
@@ -72,7 +72,7 @@ func formatMessage(dto queue.TaskDTO) string {
 }
 
 // postWebhook 向 webhookURL POST 任务 JSON（外层包 event 字段）
-func (n *Notifier) postWebhook(ctx context.Context, dto queue.TaskDTO) error {
+func (n *Notifier) postWebhook(ctx context.Context, dto *queue.TaskDTO) error {
 	payload, err := json.Marshal(map[string]any{
 		"event": "task_finished",
 		"task":  dto,
@@ -90,7 +90,7 @@ func (n *Notifier) postWebhook(ctx context.Context, dto queue.TaskDTO) error {
 		return err
 	}
 	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode >= 300 {
+	if resp.StatusCode >= http.StatusMultipleChoices {
 		return fmt.Errorf("webhook 返回 %s", resp.Status)
 	}
 	return nil

--- a/internal/queue/manager.go
+++ b/internal/queue/manager.go
@@ -48,7 +48,7 @@ type Manager struct {
 	order       []*task // 插入顺序（最早在前），List() 据此反转为最新优先
 	monitorTask *task
 	onChange    func(*TaskDTO)
-	onTerminal  func(TaskDTO) // 任务终结通知（completed/最终 failed，取消与自动重试不触发）
+	onTerminal  func(*TaskDTO) // 任务终结通知（completed/最终 failed，取消与自动重试不触发）
 	runCtx      context.Context
 
 	monitorMu sync.Mutex // 串行化 monitor 切换，保证同一时刻至多一个 monitor 任务在运行
@@ -178,7 +178,7 @@ func (m *Manager) SetOnChange(fn func(*TaskDTO)) {
 
 // SetOnTerminal 设置任务终结回调：completed 与自动重试耗尽后的最终 failed 触发，
 // canceled 与重试中的中间失败不触发；按任务粒度调用
-func (m *Manager) SetOnTerminal(fn func(TaskDTO)) {
+func (m *Manager) SetOnTerminal(fn func(*TaskDTO)) {
 	m.mu.Lock()
 	m.onTerminal = fn
 	m.mu.Unlock()
@@ -190,7 +190,8 @@ func (m *Manager) fireTerminal(t *task) {
 	fn := m.onTerminal
 	m.mu.Unlock()
 	if fn != nil {
-		fn(t.ToDTO())
+		dto := t.ToDTO()
+		fn(&dto)
 	}
 }
 
@@ -372,7 +373,7 @@ func (m *Manager) runHistoryTask(ctx context.Context, t *task) {
 	}
 	t.mu.Lock()
 	t.phase = phaseDownloading
-	spec := downloader.HistorySpec{
+	spec := &downloader.HistorySpec{
 		ChatID:        t.chatID,
 		TaskID:        t.id,
 		FromMessageID: t.scanCursor,
@@ -467,7 +468,7 @@ func (m *Manager) scheduleRetry(t *task, attempt int, cause error) {
 // Enqueue 创建并提交一个新任务。history 任务进入有界 worker 池排队；
 // monitor 任务立即以独立 goroutine 长期运行（不占用 history 配额），ChatID 为 0 表示停止监控。
 // spec 携带 ChatID 以及 history 任务的过滤器/单消息参数（monitor 忽略后两者）。
-func (m *Manager) Enqueue(kind Kind, spec downloader.HistorySpec, chatTitle string) (TaskDTO, error) {
+func (m *Manager) Enqueue(kind Kind, spec *downloader.HistorySpec, chatTitle string) (TaskDTO, error) {
 	switch kind {
 	case KindHistory:
 		return m.enqueueHistory(spec, chatTitle)
@@ -480,7 +481,7 @@ func (m *Manager) Enqueue(kind Kind, spec downloader.HistorySpec, chatTitle stri
 
 // enqueueHistory 创建 history 任务、持久化后投递给 worker 池；
 // 排队中/运行中的重复任务拒绝创建（整聊天任务按 chatID 去重，单消息任务按 (chatID, messageID) 去重）
-func (m *Manager) enqueueHistory(spec downloader.HistorySpec, chatTitle string) (TaskDTO, error) {
+func (m *Manager) enqueueHistory(spec *downloader.HistorySpec, chatTitle string) (TaskDTO, error) {
 	m.mu.Lock()
 	for _, existing := range m.tasks {
 		if existing.kind != KindHistory || existing.chatID != spec.ChatID {
@@ -537,7 +538,7 @@ func (m *Manager) enqueueMonitor(chatID int64, chatTitle string) (TaskDTO, error
 		return TaskDTO{}, nil
 	}
 
-	t := newTask(KindMonitor, downloader.HistorySpec{ChatID: chatID}, chatTitle)
+	t := newTask(KindMonitor, &downloader.HistorySpec{ChatID: chatID}, chatTitle)
 	t.mu.Lock()
 	t.status = StatusRunning
 	now := time.Now()
@@ -689,7 +690,7 @@ func (m *Manager) Retry(id string) (TaskDTO, error) {
 
 	t.mu.Lock()
 	status, kind, chatTitle := t.status, t.kind, t.chatTitle
-	spec := downloader.HistorySpec{ChatID: t.chatID, Filters: t.filters, MessageID: t.messageID}
+	spec := &downloader.HistorySpec{ChatID: t.chatID, Filters: t.filters, MessageID: t.messageID}
 	t.mu.Unlock()
 
 	if status != StatusFailed && status != StatusCanceled {

--- a/internal/queue/queue.go
+++ b/internal/queue/queue.go
@@ -42,7 +42,7 @@ const (
 // 使本包可在无真实 TDLib 连接的情况下进行单元测试。
 type ChatDownloader interface {
 	CountHistoryMedia(ctx context.Context, chatID int64, mediaTypes []string) (int64, error)
-	DownloadHistoryMedia(ctx context.Context, spec downloader.HistorySpec) error
+	DownloadHistoryMedia(ctx context.Context, spec *downloader.HistorySpec) error
 	SetMonitorTask(taskID string, chatID int64)
 	SetRecordFunc(fn func(context.Context, downloader.RecordEvent))
 	SetScanProgressFunc(fn func(taskID string, scannedMessages, foundMedia, scanCursor int64))

--- a/internal/queue/queue_test.go
+++ b/internal/queue/queue_test.go
@@ -96,11 +96,11 @@ func (f *fakeClient) CountHistoryMedia(_ context.Context, chatID int64, _ []stri
 	return f.counts[chatID], nil
 }
 
-func (f *fakeClient) DownloadHistoryMedia(ctx context.Context, spec downloader.HistorySpec) error {
+func (f *fakeClient) DownloadHistoryMedia(ctx context.Context, spec *downloader.HistorySpec) error {
 	taskID := spec.TaskID
 	f.mu.Lock()
 	f.calls[taskID]++
-	f.specs[taskID] = append(f.specs[taskID], spec)
+	f.specs[taskID] = append(f.specs[taskID], *spec)
 	f.mu.Unlock()
 
 	select {
@@ -185,7 +185,7 @@ func TestEnqueueLifecycle_QueuedRunningCompleted(t *testing.T) {
 	fc := newFakeClient()
 	m := NewManager(fc, newTestStore(t), logger.New(logger.LevelError), 1, 0)
 
-	dto, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 1}, "chat-1")
+	dto, err := m.Enqueue(KindHistory, &downloader.HistorySpec{ChatID: 1}, "chat-1")
 	if err != nil {
 		t.Fatalf("Enqueue() error = %v", err)
 	}
@@ -214,7 +214,7 @@ func TestRunHistoryTask_CountsBeforeDownload(t *testing.T) {
 	t.Cleanup(cancel)
 	go m.Run(ctx)
 
-	dto, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 1}, "chat-1")
+	dto, err := m.Enqueue(KindHistory, &downloader.HistorySpec{ChatID: 1}, "chat-1")
 	if err != nil {
 		t.Fatalf("Enqueue() error = %v", err)
 	}
@@ -252,7 +252,7 @@ func TestRunHistoryTask_CountFailureFallsBack(t *testing.T) {
 	m, fc := newTestManager(t, 1)
 	fc.setCountErr(1, errors.New("count boom"))
 
-	dto, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 1}, "chat-1")
+	dto, err := m.Enqueue(KindHistory, &downloader.HistorySpec{ChatID: 1}, "chat-1")
 	if err != nil {
 		t.Fatalf("Enqueue() error = %v", err)
 	}
@@ -268,13 +268,13 @@ func TestRunHistoryTask_CountFailureFallsBack(t *testing.T) {
 func TestCancel_QueuedTask(t *testing.T) {
 	m, fc := newTestManager(t, 1)
 
-	dto1, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 1}, "chat-1")
+	dto1, err := m.Enqueue(KindHistory, &downloader.HistorySpec{ChatID: 1}, "chat-1")
 	if err != nil {
 		t.Fatalf("Enqueue(task1) error = %v", err)
 	}
 	waitForStatus(t, m, dto1.ID, StatusRunning, testWaitTimeout)
 
-	dto2, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 2}, "chat-2")
+	dto2, err := m.Enqueue(KindHistory, &downloader.HistorySpec{ChatID: 2}, "chat-2")
 	if err != nil {
 		t.Fatalf("Enqueue(task2) error = %v", err)
 	}
@@ -302,13 +302,13 @@ func TestCancel_QueuedTask(t *testing.T) {
 func TestCancel_QueuedTask_DoneClosedOnce(t *testing.T) {
 	m, fc := newTestManager(t, 1)
 
-	dto1, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 1}, "chat-1")
+	dto1, err := m.Enqueue(KindHistory, &downloader.HistorySpec{ChatID: 1}, "chat-1")
 	if err != nil {
 		t.Fatalf("Enqueue(task1) error = %v", err)
 	}
 	waitForStatus(t, m, dto1.ID, StatusRunning, testWaitTimeout)
 
-	dto2, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 2}, "chat-2")
+	dto2, err := m.Enqueue(KindHistory, &downloader.HistorySpec{ChatID: 2}, "chat-2")
 	if err != nil {
 		t.Fatalf("Enqueue(task2) error = %v", err)
 	}
@@ -343,7 +343,7 @@ func TestCancel_QueuedTask_DoneClosedOnce(t *testing.T) {
 func TestCancel_RunningTask(t *testing.T) {
 	m, fc := newTestManager(t, 1)
 
-	dto, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 1}, "chat-1")
+	dto, err := m.Enqueue(KindHistory, &downloader.HistorySpec{ChatID: 1}, "chat-1")
 	if err != nil {
 		t.Fatalf("Enqueue() error = %v", err)
 	}
@@ -360,7 +360,7 @@ func TestCancel_RunningTask(t *testing.T) {
 func TestRetry_FailedTask(t *testing.T) {
 	m, fc := newTestManager(t, 1)
 
-	dto, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 1}, "chat-1")
+	dto, err := m.Enqueue(KindHistory, &downloader.HistorySpec{ChatID: 1}, "chat-1")
 	if err != nil {
 		t.Fatalf("Enqueue() error = %v", err)
 	}
@@ -390,7 +390,7 @@ func TestRetry_FailedTask(t *testing.T) {
 	}
 
 	t.Run("disallowed on non-terminal status", func(t *testing.T) {
-		dto2, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 2}, "chat-2")
+		dto2, err := m.Enqueue(KindHistory, &downloader.HistorySpec{ChatID: 2}, "chat-2")
 		if err != nil {
 			t.Fatalf("Enqueue() error = %v", err)
 		}
@@ -407,13 +407,13 @@ func TestRetry_FailedTask(t *testing.T) {
 func TestMaxConcurrentTasks_Serializes(t *testing.T) {
 	m, fc := newTestManager(t, 1)
 
-	dto1, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 1}, "chat-1")
+	dto1, err := m.Enqueue(KindHistory, &downloader.HistorySpec{ChatID: 1}, "chat-1")
 	if err != nil {
 		t.Fatalf("Enqueue(task1) error = %v", err)
 	}
 	waitForStatus(t, m, dto1.ID, StatusRunning, testWaitTimeout)
 
-	dto2, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 2}, "chat-2")
+	dto2, err := m.Enqueue(KindHistory, &downloader.HistorySpec{ChatID: 2}, "chat-2")
 	if err != nil {
 		t.Fatalf("Enqueue(task2) error = %v", err)
 	}
@@ -436,7 +436,7 @@ func TestMaxConcurrentTasks_Serializes(t *testing.T) {
 func TestMonitor_DoesNotBlockHistoryQueue(t *testing.T) {
 	m, fc := newTestManager(t, 1)
 
-	dto1, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 1}, "chat-1")
+	dto1, err := m.Enqueue(KindHistory, &downloader.HistorySpec{ChatID: 1}, "chat-1")
 	if err != nil {
 		t.Fatalf("Enqueue(history) error = %v", err)
 	}
@@ -446,7 +446,7 @@ func TestMonitor_DoesNotBlockHistoryQueue(t *testing.T) {
 	var monDTO TaskDTO
 	var monErr error
 	go func() {
-		monDTO, monErr = m.Enqueue(KindMonitor, downloader.HistorySpec{ChatID: 999}, "monitor-chat")
+		monDTO, monErr = m.Enqueue(KindMonitor, &downloader.HistorySpec{ChatID: 999}, "monitor-chat")
 		close(done)
 	}()
 
@@ -465,7 +465,7 @@ func TestMonitor_DoesNotBlockHistoryQueue(t *testing.T) {
 		t.Fatalf("client monitor association = (%s,%d), want (%s,999)", mid, mchat, monDTO.ID)
 	}
 
-	stopped, err := m.Enqueue(KindMonitor, downloader.HistorySpec{ChatID: 0}, "")
+	stopped, err := m.Enqueue(KindMonitor, &downloader.HistorySpec{ChatID: 0}, "")
 	if err != nil {
 		t.Fatalf("Enqueue(stop monitor) error = %v", err)
 	}
@@ -485,13 +485,13 @@ func TestMonitor_DoesNotBlockHistoryQueue(t *testing.T) {
 func TestMonitor_SwitchCancelsPrevious(t *testing.T) {
 	m, fc := newTestManager(t, 1)
 
-	first, err := m.Enqueue(KindMonitor, downloader.HistorySpec{ChatID: 111}, "first")
+	first, err := m.Enqueue(KindMonitor, &downloader.HistorySpec{ChatID: 111}, "first")
 	if err != nil {
 		t.Fatalf("Enqueue(first monitor) error = %v", err)
 	}
 	waitForStatus(t, m, first.ID, StatusRunning, testWaitTimeout)
 
-	second, err := m.Enqueue(KindMonitor, downloader.HistorySpec{ChatID: 222}, "second")
+	second, err := m.Enqueue(KindMonitor, &downloader.HistorySpec{ChatID: 222}, "second")
 	if err != nil {
 		t.Fatalf("Enqueue(second monitor) error = %v", err)
 	}
@@ -508,17 +508,17 @@ func TestMonitor_SwitchCancelsPrevious(t *testing.T) {
 func TestEnqueueHistory_DuplicateChatRejected(t *testing.T) {
 	m, fc := newTestManager(t, 1)
 
-	dto1, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 1}, "chat-1")
+	dto1, err := m.Enqueue(KindHistory, &downloader.HistorySpec{ChatID: 1}, "chat-1")
 	if err != nil {
 		t.Fatalf("Enqueue(task1) error = %v", err)
 	}
 	waitForStatus(t, m, dto1.ID, StatusRunning, testWaitTimeout)
 
-	if _, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 1}, "chat-1"); err == nil {
+	if _, err := m.Enqueue(KindHistory, &downloader.HistorySpec{ChatID: 1}, "chat-1"); err == nil {
 		t.Fatal("对处于 running 状态的同一 chat_id 重复 Enqueue 应返回错误")
 	}
 
-	dto2, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 2}, "chat-2")
+	dto2, err := m.Enqueue(KindHistory, &downloader.HistorySpec{ChatID: 2}, "chat-2")
 	if err != nil {
 		t.Fatalf("Enqueue(task2) error = %v", err)
 	}
@@ -527,7 +527,7 @@ func TestEnqueueHistory_DuplicateChatRejected(t *testing.T) {
 		t.Fatalf("task2 should still be queued while task1 occupies the only worker, got %+v ok=%v", got, ok)
 	}
 
-	if _, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 2}, "chat-2"); err == nil {
+	if _, err := m.Enqueue(KindHistory, &downloader.HistorySpec{ChatID: 2}, "chat-2"); err == nil {
 		t.Fatal("对处于 queued 状态的同一 chat_id 重复 Enqueue 应返回错误")
 	}
 
@@ -547,7 +547,7 @@ func TestEnqueueHistory_DuplicateChatRejected(t *testing.T) {
 	waitForStatus(t, m, dto2.ID, StatusRunning, testWaitTimeout)
 
 	// task1 已终结，chat-1 应允许重新入队
-	dto3, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 1}, "chat-1")
+	dto3, err := m.Enqueue(KindHistory, &downloader.HistorySpec{ChatID: 1}, "chat-1")
 	if err != nil {
 		t.Fatalf("任务终结后重新 Enqueue(chat-1) error = %v", err)
 	}
@@ -643,7 +643,7 @@ func TestNewManager_ResumesInterruptedTasksFromStore(t *testing.T) {
 func TestHandleRecordEvent_AsyncPersistPreservesOrder(t *testing.T) {
 	m, fc := newTestManager(t, 1)
 
-	dto, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 1}, "chat-1")
+	dto, err := m.Enqueue(KindHistory, &downloader.HistorySpec{ChatID: 1}, "chat-1")
 	if err != nil {
 		t.Fatalf("Enqueue() error = %v", err)
 	}
@@ -698,7 +698,7 @@ func TestRunHistoryTask_AutoRetry(t *testing.T) {
 	t.Cleanup(cancel)
 	go m.Run(ctx)
 
-	dto, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 1}, "chat-1")
+	dto, err := m.Enqueue(KindHistory, &downloader.HistorySpec{ChatID: 1}, "chat-1")
 	if err != nil {
 		t.Fatalf("Enqueue() error = %v", err)
 	}
@@ -735,7 +735,7 @@ func TestEnqueue_FiltersFlowThroughSpecAndRetry(t *testing.T) {
 	go m.Run(ctx)
 
 	filters := downloader.HistoryFilters{MediaTypes: []string{"photo"}, DateFrom: 1700000000, MaxFileSize: 1 << 20}
-	dto, err := m.Enqueue(KindHistory, downloader.HistorySpec{ChatID: 1, Filters: filters}, "chat-1")
+	dto, err := m.Enqueue(KindHistory, &downloader.HistorySpec{ChatID: 1, Filters: filters}, "chat-1")
 	if err != nil {
 		t.Fatalf("Enqueue() error = %v", err)
 	}

--- a/internal/queue/scheduler.go
+++ b/internal/queue/scheduler.go
@@ -53,7 +53,7 @@ func (m *Manager) fireDueSchedules(ctx context.Context) {
 		if r.Filters != "" {
 			_ = json.Unmarshal([]byte(r.Filters), &filters) // 解析失败退化为不过滤
 		}
-		spec := downloader.HistorySpec{ChatID: r.ChatID, Filters: filters}
+		spec := &downloader.HistorySpec{ChatID: r.ChatID, Filters: filters}
 		if _, err := m.Enqueue(KindHistory, spec, r.ChatTitle); err != nil {
 			// 常见于同聊天已有排队/运行中的任务，跳过本次触发
 			m.logger.Info("定时计划 %s（聊天 %d）本次触发跳过: %v", r.ID, r.ChatID, err)

--- a/internal/queue/task.go
+++ b/internal/queue/task.go
@@ -64,7 +64,7 @@ const scanNotifyMinGap = 500 * time.Millisecond
 const recordNotifyMinGap = 250 * time.Millisecond
 
 // newTask 创建一个初始状态为 queued 的任务；spec 携带 ChatID/Filters/MessageID
-func newTask(kind Kind, spec downloader.HistorySpec, chatTitle string) *task {
+func newTask(kind Kind, spec *downloader.HistorySpec, chatTitle string) *task {
 	return &task{
 		id:        generateID(),
 		kind:      kind,

--- a/internal/store/schedules.go
+++ b/internal/store/schedules.go
@@ -36,6 +36,8 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?)`
 }
 
 // ListSchedules 返回全部定时计划，按创建时间倒序
+//
+//nolint:dupl // 与 ListTasks 结构同形但行类型/扫描器不同，泛型化收益低于可读性损失
 func (s *Store) ListSchedules(ctx context.Context) ([]*ScheduleRow, error) {
 	const q = `
 SELECT id, chat_id, chat_title, interval_min, filters, enabled, last_run, created_at

--- a/internal/store/tasks.go
+++ b/internal/store/tasks.go
@@ -80,6 +80,8 @@ WHERE id = ?`
 }
 
 // ListTasks 返回全部任务，按创建时间倒序排列
+//
+//nolint:dupl // 与 ListSchedules 结构同形但行类型/扫描器不同，泛型化收益低于可读性损失
 func (s *Store) ListTasks(ctx context.Context) ([]*TaskRow, error) {
 	const q = `
 SELECT id, kind, chat_id, chat_title, status, created_at, started_at, finished_at,

--- a/internal/telegram/client.go
+++ b/internal/telegram/client.go
@@ -74,8 +74,6 @@ const (
 
 	copyBufferSize = 1 << 20 // 1MB copy buffer for cross-device fallback
 
-	// appVersion 上报给 TDLib 的设备/应用版本
-	appVersion = "1.0"
 	// dbDirPerm 是 TDLib 数据库目录权限
 	dbDirPerm = 0o700
 	// tdNotFoundCode 是 TDLib 列表耗尽时返回的错误码
@@ -83,6 +81,16 @@ const (
 	// logoutCloseTimeout 是 LogOut 后等待 TDLib 销毁本地数据并进入 closed 状态的上限
 	logoutCloseTimeout = 10 * time.Second
 )
+
+// appVersion 上报给 TDLib 的设备/应用版本，由 SetAppVersion 在启动时注入构建版本
+var appVersion = "dev"
+
+// SetAppVersion 设置上报给 TDLib 的应用版本（须在 NewClient/Connect 之前调用）
+func SetAppVersion(v string) {
+	if v != "" {
+		appVersion = v
+	}
+}
 
 // CodeFunc 提供登录验证码
 type CodeFunc func(ctx context.Context) (string, error)

--- a/internal/telegram/client.go
+++ b/internal/telegram/client.go
@@ -268,7 +268,7 @@ func tdCall[T any](ctx context.Context, timeout time.Duration, fn func(context.C
 		err error
 	}
 	ch := make(chan outcome, 1)
-	go func() {
+	go func() { // #nosec G118 -- 有意脱离请求 ctx：见函数注释，规避绑定的并发崩溃
 		v, err := fn(context.Background())
 		ch <- outcome{v, err}
 	}()
@@ -932,14 +932,14 @@ func (c *Client) moveWithRetry(src, dst string) error {
 // （后续 os.Stat 存在性检查会将其误判为已下载完成），先写入同目录 .part 临时文件，
 // 全部成功后再原子 rename 到目标路径；任何环节失败都会清理临时文件。
 func copyFile(src, dst string) error {
-	in, err := os.Open(filepath.Clean(src))
+	in, err := os.Open(filepath.Clean(src)) // #nosec G304 -- src 为 TDLib 缓存内部路径
 	if err != nil {
 		return err
 	}
 	defer func() { _ = in.Close() }()
 
 	tmp := filepath.Clean(dst) + ".part"
-	out, err := os.Create(tmp)
+	out, err := os.Create(tmp) // #nosec G304 -- tmp 由内部下载计划路径派生
 	if err != nil {
 		return err
 	}
@@ -1136,40 +1136,26 @@ func (c *Client) CountHistoryMedia(ctx context.Context, chatID int64, mediaTypes
 	return total, nil
 }
 
-func (c *Client) DownloadHistoryMedia(ctx context.Context, spec downloader.HistorySpec) error {
+// DownloadHistoryMedia 按 spec 下载聊天历史媒体：整聊天任务从游标续扫并流水线分发下载，
+// 单消息任务（spec.MessageID != 0）只下载指定消息；恢复任务先补下被重启清扫的中断行
+func (c *Client) DownloadHistoryMedia(ctx context.Context, spec *downloader.HistorySpec) error {
 	td := c.client()
 	if td == nil {
 		return errors.New("TDLib 未连接")
 	}
-	chatID, taskID := spec.ChatID, spec.TaskID
 	if spec.FromMessageID > 0 {
-		c.logger.Info("继续下载聊天 %d 的历史媒体文件（游标 %d）", chatID, spec.FromMessageID)
+		c.logger.Info("继续下载聊天 %d 的历史媒体文件（游标 %d）", spec.ChatID, spec.FromMessageID)
 	} else {
-		c.logger.Info("开始下载聊天 %d 的历史媒体文件", chatID)
+		c.logger.Info("开始下载聊天 %d 的历史媒体文件", spec.ChatID)
 	}
 
-	if _, err := tdCall(ctx, metadataTimeout, func(cc context.Context) (*tdclient.Chat, error) {
-		return td.GetChat(cc, &tdclient.GetChatRequest{ChatId: chatID})
-	}); err != nil {
-		return fmt.Errorf("无法访问聊天 %d: %w", chatID, err)
+	closeChat, err := c.openChatForHistory(ctx, td, spec.ChatID)
+	if err != nil {
+		return err
 	}
-
-	// 打开聊天，促使 TDLib 主动从服务器同步历史；冷缓存时首批 GetChatHistory 常为空，
-	// 否则可能在历史尚未拉取就误判"已完成"。结束时关闭以释放 TDLib 资源。
-	_, openErr := tdCall(ctx, metadataTimeout, func(cc context.Context) (*tdclient.Ok, error) {
-		return td.OpenChat(cc, &tdclient.OpenChatRequest{ChatId: chatID})
-	})
-	if openErr != nil {
-		c.logger.Warn("打开聊天失败（继续尝试拉取历史）: %v", openErr)
-	} else {
-		defer func() { _, _ = td.CloseChat(context.Background(), &tdclient.CloseChatRequest{ChatId: chatID}) }()
+	if closeChat != nil {
+		defer closeChat()
 	}
-
-	batchSize := c.config.Download.BatchSize
-	if batchSize <= 0 || batchSize > DefaultMessageLimit {
-		batchSize = DefaultMessageLimit
-	}
-	limit := int32(batchSize) // 已上界钳制到 DefaultMessageLimit(100)，不会溢出
 
 	// 扫描与下载流水线：扫描 goroutine 持续翻页发现媒体并立即分发下载，
 	// sem 限制扫描最多领先下载 partitionSize 个在途媒体（内存与队列长度上界）
@@ -1177,16 +1163,8 @@ func (c *Client) DownloadHistoryMedia(ctx context.Context, spec downloader.Histo
 	if partitionSize <= 0 {
 		partitionSize = config.DefaultPartitionSize
 	}
-
-	var (
-		wg              sync.WaitGroup
-		sem             = make(chan struct{}, partitionSize)
-		fromMsgID       = spec.FromMessageID // 0 = 从最新开始；>0 = 断点续扫
-		scannedMessages int64
-		foundMedia      int64
-	)
-	emptyStreak := 0
-	lastScanLog := time.Now()
+	var wg sync.WaitGroup
+	sem := make(chan struct{}, partitionSize)
 
 	// dispatch 将单个媒体投入下载流水线（受 sem 在途上限约束）
 	dispatch := func(mi *downloader.MediaInfo) error {
@@ -1225,56 +1203,7 @@ func (c *Client) DownloadHistoryMedia(ctx context.Context, spec downloader.Histo
 		}
 	}
 
-	scanErr := func() error {
-		for {
-			if err := ctx.Err(); err != nil {
-				return err
-			}
-
-			pageMsgs, err := fetchHistoryPage(ctx, td, chatID, fromMsgID, limit)
-			if err != nil {
-				return err
-			}
-
-			if len(pageMsgs) == 0 {
-				emptyStreak++
-				stop, err := awaitNextHistoryPage(ctx, emptyStreak)
-				if err != nil {
-					return err
-				}
-				if stop {
-					return nil
-				}
-				continue
-			}
-			emptyStreak = 0
-
-			media, lastMsgID, pastDateFrom := c.extractBatchMedia(pageMsgs, taskID, spec.Filters)
-			fromMsgID = lastMsgID // 推进到本页最旧消息
-			scannedMessages += int64(len(pageMsgs))
-			foundMedia += int64(len(media))
-			// 游标随页推进即上报持久化；本页/在途媒体若在落盘后被杀，
-			// 由启动清扫（interrupted）+ 恢复补下（RetryMessageIDs）兜底，不会漏
-			c.reportScanProgress(taskID, scannedMessages, foundMedia, fromMsgID)
-
-			c.downloader.PlanBatch(media)
-			for _, m := range media {
-				if err := dispatch(m); err != nil {
-					return err
-				}
-			}
-			if pastDateFrom {
-				c.logger.Info("历史扫描已越过起始日期，提前结束")
-				return nil
-			}
-
-			if time.Since(lastScanLog) >= scanLogInterval {
-				c.logger.Info("扫描进度: 已扫描 %d 条消息，发现 %d 个媒体", scannedMessages, foundMedia)
-				lastScanLog = time.Now()
-			}
-		}
-	}()
-
+	scannedMessages, foundMedia, scanErr := c.scanHistoryPages(ctx, td, spec, dispatch)
 	if scanErr == nil {
 		c.logger.Info("历史扫描完成: 共扫描 %d 条消息，发现 %d 个媒体", scannedMessages, foundMedia)
 	}
@@ -1289,9 +1218,92 @@ func (c *Client) DownloadHistoryMedia(ctx context.Context, spec downloader.Histo
 	return nil
 }
 
+// openChatForHistory 校验聊天可访问并打开聊天，促使 TDLib 主动从服务器同步历史；
+// 冷缓存时首批 GetChatHistory 常为空，否则可能在历史尚未拉取就误判"已完成"。
+// 返回的 closeFn（可为 nil）应在拉取结束后调用以释放 TDLib 资源。
+func (c *Client) openChatForHistory(ctx context.Context, td *tdclient.Client, chatID int64) (closeFn func(), err error) {
+	if _, err := tdCall(ctx, metadataTimeout, func(cc context.Context) (*tdclient.Chat, error) {
+		return td.GetChat(cc, &tdclient.GetChatRequest{ChatId: chatID})
+	}); err != nil {
+		return nil, fmt.Errorf("无法访问聊天 %d: %w", chatID, err)
+	}
+
+	if _, openErr := tdCall(ctx, metadataTimeout, func(cc context.Context) (*tdclient.Ok, error) {
+		return td.OpenChat(cc, &tdclient.OpenChatRequest{ChatId: chatID})
+	}); openErr != nil {
+		c.logger.Warn("打开聊天失败（继续尝试拉取历史）: %v", openErr)
+		return nil, nil
+	}
+	return func() {
+		_, _ = td.CloseChat(context.Background(), &tdclient.CloseChatRequest{ChatId: chatID})
+	}, nil
+}
+
+// scanHistoryPages 从 spec.FromMessageID 起向更旧方向翻页扫描，按任务过滤器筛选并分发下载；
+// 游标随页推进经 reportScanProgress 上报持久化
+func (c *Client) scanHistoryPages(
+	ctx context.Context, td *tdclient.Client, spec *downloader.HistorySpec,
+	dispatch func(*downloader.MediaInfo) error,
+) (scannedMessages, foundMedia int64, err error) {
+	batchSize := c.config.Download.BatchSize
+	if batchSize <= 0 || batchSize > DefaultMessageLimit {
+		batchSize = DefaultMessageLimit
+	}
+	limit := int32(batchSize) // 已上界钳制到 DefaultMessageLimit(100)，不会溢出
+
+	fromMsgID := spec.FromMessageID // 0 = 从最新开始；>0 = 断点续扫
+	emptyStreak := 0
+	lastScanLog := time.Now()
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return scannedMessages, foundMedia, err
+		}
+
+		pageMsgs, err := fetchHistoryPage(ctx, td, spec.ChatID, fromMsgID, limit)
+		if err != nil {
+			return scannedMessages, foundMedia, err
+		}
+
+		if len(pageMsgs) == 0 {
+			emptyStreak++
+			stop, err := awaitNextHistoryPage(ctx, emptyStreak)
+			if err != nil || stop {
+				return scannedMessages, foundMedia, err
+			}
+			continue
+		}
+		emptyStreak = 0
+
+		media, lastMsgID, pastDateFrom := c.extractBatchMedia(pageMsgs, spec.TaskID, spec.Filters)
+		fromMsgID = lastMsgID // 推进到本页最旧消息
+		scannedMessages += int64(len(pageMsgs))
+		foundMedia += int64(len(media))
+		// 游标随页推进即上报持久化；本页/在途媒体若在落盘后被杀，
+		// 由启动清扫（interrupted）+ 恢复补下（RetryMessageIDs）兜底，不会漏
+		c.reportScanProgress(spec.TaskID, scannedMessages, foundMedia, fromMsgID)
+
+		c.downloader.PlanBatch(media)
+		for _, m := range media {
+			if err := dispatch(m); err != nil {
+				return scannedMessages, foundMedia, err
+			}
+		}
+		if pastDateFrom {
+			c.logger.Info("历史扫描已越过起始日期，提前结束")
+			return scannedMessages, foundMedia, nil
+		}
+
+		if time.Since(lastScanLog) >= scanLogInterval {
+			c.logger.Info("扫描进度: 已扫描 %d 条消息，发现 %d 个媒体", scannedMessages, foundMedia)
+			lastScanLog = time.Now()
+		}
+	}
+}
+
 // retryInterruptedMessages 逐条重取并补下恢复任务的中断消息；消息已删除或无媒体时记警告跳过
 func (c *Client) retryInterruptedMessages(
-	ctx context.Context, td *tdclient.Client, spec downloader.HistorySpec,
+	ctx context.Context, td *tdclient.Client, spec *downloader.HistorySpec,
 	dispatch func(*downloader.MediaInfo) error,
 ) error {
 	var batch []*downloader.MediaInfo
@@ -1323,7 +1335,7 @@ func (c *Client) retryInterruptedMessages(
 
 // downloadSingleHistoryMessage 下载单条消息的媒体（t.me 消息链接任务）
 func (c *Client) downloadSingleHistoryMessage(
-	ctx context.Context, td *tdclient.Client, spec downloader.HistorySpec,
+	ctx context.Context, td *tdclient.Client, spec *downloader.HistorySpec,
 	dispatch func(*downloader.MediaInfo) error,
 ) error {
 	msg, err := tdCall(ctx, metadataTimeout, func(cc context.Context) (*tdclient.Message, error) {

--- a/internal/web/handlers.go
+++ b/internal/web/handlers.go
@@ -183,7 +183,9 @@ func (s *Server) handleAuthLogout(w http.ResponseWriter, r *http.Request) {
 	if !s.requireReady(w) {
 		return
 	}
-	for _, t := range s.queue.List() {
+	tasks := s.queue.List()
+	for i := range tasks {
+		t := &tasks[i]
 		if t.Status == string(queue.StatusQueued) || t.Status == string(queue.StatusRunning) {
 			if err := s.queue.Cancel(t.ID); err != nil {
 				s.logger.Warn("登出前取消任务 %s 失败: %v", t.ID, err)
@@ -271,7 +273,7 @@ func (s *Server) handleTasksCreate(w http.ResponseWriter, r *http.Request) {
 	if title == "" {
 		title = s.chatTitle(body.ChatID)
 	}
-	spec := downloader.HistorySpec{ChatID: body.ChatID, Filters: body.Filters, MessageID: body.MessageID}
+	spec := &downloader.HistorySpec{ChatID: body.ChatID, Filters: body.Filters, MessageID: body.MessageID}
 	dto, err := s.queue.Enqueue(kind, spec, title)
 	if err != nil {
 		s.writeError(w, http.StatusConflict, err.Error())

--- a/internal/web/security.go
+++ b/internal/web/security.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	// webTokenEnv 提供访问令牌；监听非本地地址时必需，本地监听可选。
-	webTokenEnv = "TG_DOWN_WEB_TOKEN"
+	webTokenEnv = "TG_DOWN_WEB_TOKEN" // #nosec G101 -- 环境变量名，非硬编码凭据
 	// allowedHostsEnv 是额外放行的 Host 白名单（逗号分隔），用于反向代理等场景。
 	allowedHostsEnv = "TG_DOWN_WEB_ALLOWED_HOSTS"
 	// maxRequestBodyBytes 限制请求体大小，防止内存耗尽 DoS。

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -344,6 +344,7 @@ func (s *Server) onLog(level, msg string) {
 func (s *Server) snapshot() stateSnapshot {
 	state, stateErr := s.currentState()
 	return stateSnapshot{
+		Version:          appVersion,
 		State:            state,
 		Error:            stateErr,
 		Phone:            maskPhone(s.client.Phone()),
@@ -379,7 +380,18 @@ func maskPhone(phone string) string {
 
 // --- DTOs ---
 
+// appVersion 由 SetVersion 在启动时注入构建版本，经 /api/state 暴露给前端
+var appVersion = "dev"
+
+// SetVersion 设置对外展示的应用版本（须在 Run 之前调用）
+func SetVersion(v string) {
+	if v != "" {
+		appVersion = v
+	}
+}
+
 type stateSnapshot struct {
+	Version          string                     `json:"version"`
 	State            State                      `json:"state"`
 	Error            string                     `json:"error,omitempty"`
 	Phone            string                     `json:"phone"`

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -469,6 +469,7 @@
         </div>
       </div>
       <button class="logout-btn" onclick="logout(this)">退出登录</button>
+      <div class="meta" id="appVersion" style="text-align:center;margin-top:8px;opacity:.6"></div>
     </div>
   </aside>
 
@@ -870,6 +871,7 @@ function applyState(s) {
 
   if (!ready) return;
   $("connPhone").textContent = s.phone || "-";
+  if (s.version) $("appVersion").textContent = "tg-down " + s.version;
   if (target !== lastTarget) { lastTarget = target; renderChats(); }
   renderPauseAllButtons();
   renderOverview(s);

--- a/scripts/install-tdlib.sh
+++ b/scripts/install-tdlib.sh
@@ -31,8 +31,13 @@ case "$(uname -s)" in
     ;;
   Linux)
     if command -v apt-get >/dev/null 2>&1; then
-      sudo apt-get update -y || true # transient mirror failures are non-fatal; the install below still gates
-      sudo apt-get install -y make git zlib1g-dev libssl-dev gperf cmake g++
+      # 容器/root 环境无 sudo，直接调用 apt-get
+      SUDO="sudo"
+      if [ "$(id -u)" = "0" ] || ! command -v sudo >/dev/null 2>&1; then
+        SUDO=""
+      fi
+      $SUDO apt-get update -y || true # transient mirror failures are non-fatal; the install below still gates
+      $SUDO apt-get install -y make git zlib1g-dev libssl-dev gperf cmake g++
     fi
     ;;
 esac


### PR DESCRIPTION
v2.0 里程碑 5/5（base=M4）：

- 版本注入：--version / TDLib 上报 / Web 页脚，ldflags 贯通 Makefile/release/Docker
- Docker：多阶段构建（TDLib 层独立缓存），PUID/PGID 降权，纯 env 配置；docker.yml 双原生 runner（amd64 + ubuntu-24.04-arm）构建合并 manifest 推 GHCR
- glibc 修复（closes #32）：Linux 发布包 debian:11 容器构建（glibc≥2.31 可用），自带 lib/（OpenSSL 1.1）+ $ORIGIN rpath
- 飞牛 fnOS：docs/fnos/docker-compose.yml 模板 + README 部署章节
- 发布收口：README 更新日志按真实 tag 矫正并新增 v2.0.0 条目；WORKFLOWS.md 同步

合并后流程：workflow_dispatch 预演 docker.yml → 手动 tag v2.0.0-rc1 预演 release.yml → 手动 tag v2.0.0 正式发布。