### PR TITLE
feat(downloader): 路径模板允许以 {chat_title} 替代 {chat_id} 作聊天隔离层

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,14 +282,23 @@ downloads/
 展开为空的路径段会被丢弃，因此 `{type}` / `{album}` 能自然地「消失」。
 
 > [!CAUTION]
-> 模板必须包含 `{chat_id}`，并至少包含 `{name}` 或 `{msg_id}`：前者隔离不同聊天，
-> 后者隔离同一聊天中的不同消息。缺少任一层都会让文件互相覆盖，或被当成「已下载」而跳过。
+> 模板必须至少包含 `{chat_id}` 与 `{chat_title}` 之一（聊天隔离层），并至少包含 `{name}` 或 `{msg_id}`：
+> `{chat_id}` 或 `{chat_title}` 隔离不同聊天（`{chat_title}` 在标题缺失时自动回退为 `chat_<id>`），
+> `{name}` / `{msg_id}` 隔离同一聊天中的不同消息。缺少任一层都会让文件互相覆盖，或被当成「已下载」而跳过。
 > 非法模板会被忽略并回退到默认布局。
 
 ```yaml
 download:
   # 按 ID、标题和日期归档：downloads/123456/我的频道/2024-03-05/42_video.mp4
   path_template: "{chat_id}/{chat_title}/{date}/{name}"
+```
+
+不想看到 `chat_<id>` 这种目录名？让顶层目录直接用群聊名即可（标题缺失时仍会回退 `chat_<id>` 兜底）：
+
+```yaml
+download:
+  # 顶层目录 = 群聊名：downloads/我的频道/2024-03-05/42_video.mp4
+  path_template: "{chat_title}/{date}/{name}"
 ```
 
 ---

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -108,7 +108,8 @@ type DownloadConfig struct {
 	DisableClassifyByType bool `yaml:"disable_classify_by_type"`
 	// PathTemplate 是落盘路径模板，空 = downloader.DefaultPathTemplate（即 v2.x 的既有布局）。
 	// 可用占位符：{chat_id} {chat_title} {type} {album} {date} {msg_id} {sender} {name} {ext}，
-	// 必须包含 {chat_id}，并至少包含 {name} 或 {msg_id}（否则跨聊天或同聊天文件会互相覆盖）。
+	// 必须至少包含 {chat_id} 或 {chat_title} 之一（聊天隔离；{chat_title} 缺标题时回退 chat_<id>），
+	// 并至少包含 {name} 或 {msg_id}（否则跨聊天或同聊天文件会互相覆盖）。
 	PathTemplate string `yaml:"path_template"`
 }
 

--- a/internal/downloader/template.go
+++ b/internal/downloader/template.go
@@ -78,9 +78,11 @@ func ValidatePathTemplate(tpl string) string {
 		return "路径模板包含格式错误的占位符"
 	}
 	// message_id 只在单个聊天内唯一，chat_title/sender/date 也都可能重复。
-	// 下载根目录由所有聊天共享，因此必须把不可碰撞的 chat_id 放进最终路径。
-	if !strings.Contains(tpl, "{"+phChatID+"}") {
-		return "路径模板必须包含 {chat_id}，否则不同聊天的文件可能互相覆盖"
+	// 下载根目录由所有聊天共享，因此必须把不可碰撞的 chat_id 放进最终路径；
+	// {chat_title} 也可充当聊天隔离层——标题缺失时展开逻辑回退为 chat_<id>
+	// （见 pathContext.value），不会让不同聊天的文件混进同一个目录。
+	if !strings.Contains(tpl, "{"+phChatID+"}") && !strings.Contains(tpl, "{"+phChatTitle+"}") {
+		return "路径模板必须包含 {chat_id} 或 {chat_title}，否则不同聊天的文件可能互相覆盖"
 	}
 	for _, p := range uniquePlaceholders {
 		if strings.Contains(tpl, "{"+p+"}") {

--- a/internal/downloader/template_test.go
+++ b/internal/downloader/template_test.go
@@ -118,6 +118,49 @@ func TestPlanMediaPath_ChatTitleFallsBackToID(t *testing.T) {
 	}
 }
 
+// TestPlanMediaPath_ChatTitleAsTopDir 校验纯标题模板（不含 {chat_id}）：
+// 顶层目录即群聊名；标题缺失时回退 chat_<id>，聊天隔离不塌。
+func TestPlanMediaPath_ChatTitleAsTopDir(t *testing.T) {
+	root := t.TempDir()
+	d := New(root, 1, nil)
+	d.SetClassifyByType(true)
+	d.SetPathTemplate("{chat_title}/{type}/{album}/{name}")
+
+	// 有标题：顶层目录 = 群聊名
+	_, _, got := d.planMediaPath(&MediaInfo{
+		ChatID: -100123, ChatTitle: "我的频道", MediaType: mediapkg.Photo,
+		FileName: "photo_-100123_42.jpg",
+	})
+	want := filepath.Join(root, "我的频道", "photo", "photo_-100123_42.jpg")
+	if got != want {
+		t.Errorf("落盘路径 = %q\n期望         = %q", got, want)
+	}
+
+	// 标题缺失：回退 chat_<id>，不同聊天的文件仍互不混淆
+	d2 := New(root, 1, nil)
+	d2.SetClassifyByType(true)
+	d2.SetPathTemplate("{chat_title}/{type}/{name}")
+
+	_, _, gotNoTitle := d2.planMediaPath(&MediaInfo{
+		ChatID: -100123, MediaType: mediapkg.Photo, FileName: "p.jpg", MessageID: 9,
+	})
+	wantNoTitle := filepath.Join(root, "chat_-100123", "photo", "p.jpg")
+	if gotNoTitle != wantNoTitle {
+		t.Errorf("空标题回退路径 = %q\n期望           = %q", gotNoTitle, wantNoTitle)
+	}
+
+	// 两个不同聊天即使都没有标题，也落到各自目录
+	d3 := New(root, 1, nil)
+	d3.SetClassifyByType(true)
+	d3.SetPathTemplate("{chat_title}/{type}/{name}")
+
+	_, _, gotA := d3.planMediaPath(&MediaInfo{ChatID: 1, MediaType: mediapkg.Photo, FileName: "a.jpg", MessageID: 1})
+	_, _, gotB := d3.planMediaPath(&MediaInfo{ChatID: 2, MediaType: mediapkg.Photo, FileName: "a.jpg", MessageID: 1})
+	if gotA == gotB {
+		t.Fatalf("不同聊天生成了相同路径: %s", gotA)
+	}
+}
+
 // TestPlanMediaPath_MaliciousNamesStayInRoot 校验来自 Telegram 的文件名/标题
 // （他人可控）无法越出下载根目录
 func TestPlanMediaPath_MaliciousNamesStayInRoot(t *testing.T) {
@@ -170,6 +213,9 @@ func TestValidatePathTemplate(t *testing.T) {
 		"{chat_id}/{name}",
 		"{chat_id}/{chat_title}/{date}/{name}",
 		"{chat_id}/{msg_id}{ext}",
+		// 无 {chat_id} 的纯标题隔离模板：标题缺失时回退 chat_<id>，聊天隔离不塌
+		"{chat_title}/{type}/{album}/{name}",
+		"{chat_title}/{date}/{name}",
 	}
 	for _, tpl := range valid {
 		if problem := ValidatePathTemplate(tpl); problem != "" {
@@ -179,7 +225,7 @@ func TestValidatePathTemplate(t *testing.T) {
 
 	invalid := []string{
 		"", "  ", "/{name}", "a/../{name}", "{name}\\{ext}", "{nope}/{name}",
-		"{chat_id}/{type}", "{name}", "{chat_title}/{date}/{name}",
+		"{chat_id}/{type}", "{name}", "{sender}/{date}/{name}",
 		"{chat_id}/{ChatID}/{name}", "{chat_id}/{name-typo}", "{chat_id}/{name", "{chat_id}/name}",
 	}
 	for _, tpl := range invalid {


### PR DESCRIPTION
### 动机
默认布局顶层目录是 chat_<id>，改动后顶层目录直接用群聊名称，更直观。

### 改动
- ValidatePathTemplate 从「必须包含 {chat_id}」放宽为「必须包含 {chat_id} 或 {chat_title}」
- {chat_title} 展开为空时回退 chat_<id>（既有逻辑，见 pathContext.value），纯标题模板不会让不同聊天的文件混入同一目录
- 默认模板不变，既有用户落盘布局不受影响

### 用法
path_template: {chat_title}/{type}/{album}/{name}

### 测试
go test ./internal/downloader/ ./internal/config/ 全绿；新增空标题回退、多聊天隔离用例